### PR TITLE
Task queue and email sending with Django-Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ At this point, you should be able to run the project locally:
 python manage.py runserver
 ```
 You can log in with the user created above.
+
+## Task queue
+
+Django-Q is used as a task queue, and the default setting uses the standard database as a broker.  Tasks can be serialized into the database without any additional configuration.  However, a separate process is used to run these items in the queue.  This can be launched with
+```
+python manage.py qcluster
+```
+You can cause tests to run synchronously by setting `'sync': True` in the `Q_CLUSTER` settings.

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'django.contrib.humanize',
+    'django_q',
 ]
 
 MIDDLEWARE = [
@@ -168,6 +169,17 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/accounts/login'
+
+# Configure Django-q message broker
+Q_CLUSTER = {
+    'name': 'DjangORM',
+    'workers': 4,
+    'timeout': 90,
+    'retry': 120,
+    'queue_limit': 50,
+    'bulk': 10,
+    'orm': 'default',
+}
 
 try:
     from .settings_local import *

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -27,8 +27,15 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
+import logging
 import os
+import sys
 from django.utils.translation import gettext_lazy as _
+
+_testing = False
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    _testing = True
+    logging.disable(logging.CRITICAL)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -179,7 +186,17 @@ Q_CLUSTER = {
     'queue_limit': 50,
     'bulk': 10,
     'orm': 'default',
+    'sync': _testing,
 }
+
+# Email settings
+SERVER_EMAIL = 'gigomatic.superuser@gmail.com'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# For production, be sure to set
+#EMAIL_BACKEND = 'django.core.mail.backend.smtp.EmailBackend'
+#EMAIL_HOST = ...
+#EMAIL_HOST_USER = ...
+#EMAIL_HOST_PASSWORD = ...
 
 try:
     from .settings_local import *

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -190,7 +190,7 @@ Q_CLUSTER = {
 }
 
 # Email settings
-SERVER_EMAIL = 'gigomatic.superuser@gmail.com'
+DEFAULT_FROM_EMAIL = 'gigomatic.superuser@gmail.com'
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # For production, be sure to set
 #EMAIL_BACKEND = 'django.core.mail.backend.smtp.EmailBackend'

--- a/lib/email.py
+++ b/lib/email.py
@@ -1,0 +1,27 @@
+from django.template.loader import render_to_string
+from django_q.tasks import async_task
+from markdown import markdown
+
+from go3.settings import SERVER_EMAIL
+
+SUBJECT = 'Subject:'
+DEFAULT_SUBJECT = 'Message from Gig-O-Matic'
+
+def send_mail_async(subject, message, from_email, recipient_list, html_message=None):
+    async_task('django.core.mail.send_mail',
+               subject=subject,
+               message=message,
+               from_email=from_email,
+               recipient_list=recipient_list,
+               html_message=html_message,
+               ack_failure=True
+              )
+
+def send_markdown_mail(template, context, recipient_list, from_email=SERVER_EMAIL):
+    text = render_to_string(template, context)
+    if text.startswith(SUBJECT):
+        subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]
+    else:
+        subject = DEFAULT_SUBJECT
+    html = markdown(text)
+    send_mail_async(subject, text, from_email, recipient_list, html)

--- a/lib/email.py
+++ b/lib/email.py
@@ -2,8 +2,6 @@ from django.template.loader import render_to_string
 from django_q.tasks import async_task
 from markdown import markdown
 
-from go3.settings import SERVER_EMAIL
-
 SUBJECT = 'Subject:'
 DEFAULT_SUBJECT = 'Message from Gig-O-Matic'
 
@@ -17,7 +15,7 @@ def send_mail_async(subject, message, from_email, recipient_list, html_message=N
                ack_failure=True
               )
 
-def send_markdown_mail(template, context, recipient_list, from_email=SERVER_EMAIL):
+def send_markdown_mail(template, context, recipient_list, from_email=None):
     text = render_to_string(template, context)
     if text.startswith(SUBJECT):
         subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]

--- a/lib/email.py
+++ b/lib/email.py
@@ -1,25 +1,11 @@
-from django.template.loader import render_to_string
+from django.core import mail
 from django_q.tasks import async_task
-from markdown import markdown
 
 SUBJECT = 'Subject:'
 DEFAULT_SUBJECT = 'Message from Gig-O-Matic'
 
-def send_mail_async(subject, message, from_email, recipient_list, html_message=None):
-    async_task('django.core.mail.send_mail',
-               subject=subject,
-               message=message,
-               from_email=from_email,
-               recipient_list=recipient_list,
-               html_message=html_message,
-               ack_failure=True
-              )
+def send_messages_async(messages):
+    return async_task('lib.email.do_send_messages_async', messages, ack_failure=True)
 
-def send_markdown_mail(template, context, recipient_list, from_email=None):
-    text = render_to_string(template, context)
-    if text.startswith(SUBJECT):
-        subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]
-    else:
-        subject = DEFAULT_SUBJECT
-    html = markdown(text)
-    send_mail_async(subject, text, from_email, recipient_list, html)
+def do_send_messages_async(messages):
+    mail.get_connection().send_messages(messages)

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch, mock_open
+
+from django.conf import settings
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from lib.email import send_mail_async, send_markdown_mail, DEFAULT_SUBJECT
+
+class EmailTest(TestCase):
+
+    def test_send_async(self):
+        self.assertEqual(len(mail.outbox), 0)
+        send_mail_async('Test Subject', 'Message', 'from@example.com', ['to@example.com'])
+        self.assertEqual(len(mail.outbox), 1)
+
+    @patch('builtins.open', mock_open(read_data='**Markdown**'))
+    def test_markdown_mail(self):
+        send_markdown_mail('test1', {}, ['to@example.com'])
+        message = mail.outbox[0]
+        self.assertIn('**Markdown**', message.body)
+        self.assertEqual(len(message.alternatives), 1)
+        self.assertEqual(message.alternatives[0][1], 'text/html')
+        self.assertIn('<strong>Markdown</strong>', message.alternatives[0][0])
+
+    @patch('builtins.open', mock_open(read_data='{{ key }}'))
+    def test_markdown_template(self):
+        send_markdown_mail('test2', {'key': 'value'}, ['to@example.com'])
+        message = mail.outbox[0]
+        self.assertIn('value', message.body)
+        self.assertIn('value', message.alternatives[0][0])
+
+    @patch('builtins.open', mock_open(read_data='Body'))
+    def test_markdown_default_subject(self):
+        send_markdown_mail('test3', {'key': 'value'}, ['to@example.com'])
+        self.assertEqual(mail.outbox[0].subject, DEFAULT_SUBJECT)
+
+    @patch('builtins.open', mock_open(read_data='Subject: Custom\nBody'))
+    def test_markdown_subject(self):
+        send_markdown_mail('test4', {'key': 'value'}, ['to@example.com'])
+        self.assertEqual(mail.outbox[0].subject, 'Custom')

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -1,40 +1,16 @@
-from unittest.mock import patch, mock_open
-
-from django.conf import settings
 from django.core import mail
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
-from lib.email import send_mail_async, send_markdown_mail, DEFAULT_SUBJECT
+from lib.email import send_messages_async
 
 class EmailTest(TestCase):
 
-    def test_send_async(self):
+    def test_send_messages_async(self):
         self.assertEqual(len(mail.outbox), 0)
-        send_mail_async('Test Subject', 'Message', 'from@example.com', ['to@example.com'])
+        send_messages_async([mail.EmailMessage('Subject', 'Body', 'from@example.com', ['to@example.com'])])
         self.assertEqual(len(mail.outbox), 1)
 
-    @patch('builtins.open', mock_open(read_data='**Markdown**'))
-    def test_markdown_mail(self):
-        send_markdown_mail('test1', {}, ['to@example.com'])
-        message = mail.outbox[0]
-        self.assertIn('**Markdown**', message.body)
-        self.assertEqual(len(message.alternatives), 1)
-        self.assertEqual(message.alternatives[0][1], 'text/html')
-        self.assertIn('<strong>Markdown</strong>', message.alternatives[0][0])
-
-    @patch('builtins.open', mock_open(read_data='{{ key }}'))
-    def test_markdown_template(self):
-        send_markdown_mail('test2', {'key': 'value'}, ['to@example.com'])
-        message = mail.outbox[0]
-        self.assertIn('value', message.body)
-        self.assertIn('value', message.alternatives[0][0])
-
-    @patch('builtins.open', mock_open(read_data='Body'))
-    def test_markdown_default_subject(self):
-        send_markdown_mail('test3', {'key': 'value'}, ['to@example.com'])
-        self.assertEqual(mail.outbox[0].subject, DEFAULT_SUBJECT)
-
-    @patch('builtins.open', mock_open(read_data='Subject: Custom\nBody'))
-    def test_markdown_subject(self):
-        send_markdown_mail('test4', {'key': 'value'}, ['to@example.com'])
-        self.assertEqual(mail.outbox[0].subject, 'Custom')
+    def test_send_many_messages_async(self):
+        self.assertEqual(len(mail.outbox), 0)
+        send_messages_async([mail.EmailMessage('Subject', 'Body', 'from@example.com', ['to@example.com'])] * 5)
+        self.assertEqual(len(mail.outbox), 5)

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -18,7 +18,7 @@
 from django.core.mail import EmailMultiAlternatives
 from django.http import HttpResponse
 from django.template.loader import render_to_string
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.contrib.auth.decorators import login_required
 from markdown import markdown
 
@@ -41,7 +41,8 @@ def prepare_email(member, template, context=None, **kw):
         context = dict()
     context['member'] = member
 
-    text = render_to_string(template, context)
+    with translation.override(member.preferences.locale):
+        text = render_to_string(template, context)
     if text.startswith(SUBJECT):
         subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]
     else:

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -15,9 +15,14 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from django.core.mail import EmailMultiAlternatives
 from django.http import HttpResponse
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.contrib.auth.decorators import login_required
+from markdown import markdown
+
+from lib.email import DEFAULT_SUBJECT, SUBJECT
 
 @login_required
 def motd_seen(request, pk):
@@ -29,3 +34,20 @@ def motd_seen(request, pk):
     request.user.save()
 
     return HttpResponse()
+
+
+def prepare_email(member, template, context=None, **kw):
+    if not context:
+        context = dict()
+    context['member'] = member
+
+    text = render_to_string(template, context)
+    if text.startswith(SUBJECT):
+        subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]
+    else:
+        subject = DEFAULT_SUBJECT
+    html = markdown(text)
+
+    message = EmailMultiAlternatives(subject, text, to=[member.email_line], **kw)
+    message.attach_alternative(html, 'text/html')
+    return message

--- a/member/models.py
+++ b/member/models.py
@@ -100,6 +100,10 @@ class Member(AbstractUser):
         return self.username if self.username else self.email
 
     @property
+    def email_line(self):
+        return f'{self.username} <{self.email}>' if self.username else self.email
+
+    @property
     def band_count(self):
         """ return number of bands for which I'm confirmed """
         return Assoc.member_assocs.confirmed_count(self)
@@ -131,7 +135,7 @@ class Member(AbstractUser):
         return the_motd.text if the_motd else None
 
     objects = MemberManager()
-    
+
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []
 
@@ -165,5 +169,3 @@ class MemberPreferences(models.Model):
         CALENDAR = 2, "Calendar"
 
     default_view = models.IntegerField(choices=AgendaChoices.choices, default=AgendaChoices.AGENDA)
-
-

--- a/member/tests.py
+++ b/member/tests.py
@@ -73,48 +73,64 @@ class MemberEmailTest(TestCase):
     def setUp(self):
         self.member = Member.objects.create_user('member@example.com')
 
+        _open = open  # Saves a reference to the builtin, for access after patching
+        def template_open(filename, *args, **kw):
+            # We adopt the convention that a filename begining with 't:' indicates
+            # a template that we want to inject, with the contents of the filename
+            # following the 't:'.  But the template mechanism tries to open
+            # absolute paths, so we need to look for 't:' anywhere in the filename.
+            if isinstance(filename, str) and (i := filename.find('t:')) > -1:
+                content = filename[i+2:]
+                return mock_open(read_data=content).return_value
+            return _open(filename, *args, **kw)
+
+        patch('builtins.open', template_open).start()
+
     def tearDown(self):
         Member.objects.all().delete()
 
-    @patch('builtins.open', mock_open(read_data='**Markdown**'))
     def test_markdown_mail(self):
-        message = prepare_email(self.member, 'template1')
+        message = prepare_email(self.member, 't:**Markdown**')
         self.assertIn('**Markdown**', message.body)
         self.assertEqual(len(message.alternatives), 1)
         self.assertEqual(message.alternatives[0][1], 'text/html')
         self.assertIn('<strong>Markdown</strong>', message.alternatives[0][0])
 
-    @patch('builtins.open', mock_open(read_data='{{ key }}'))
     def test_markdown_template(self):
-        message = prepare_email(self.member, 'template2', {'key': 'value'})
+        message = prepare_email(self.member, 't:{{ key }}', {'key': 'value'})
         self.assertIn('value', message.body)
         self.assertIn('value', message.alternatives[0][0])
 
-    @patch('builtins.open', mock_open(read_data='{{ member.email }}'))
     def test_markdown_template_member(self):
-        message = prepare_email(self.member, 'template3')
+        message = prepare_email(self.member, 't:{{ member.email }}')
         self.assertIn(self.member.email, message.body)
         self.assertIn(self.member.email, message.alternatives[0][0])
 
-    @patch('builtins.open', mock_open(read_data='Body'))
     def test_markdown_default_subject(self):
-        message = prepare_email(self.member, 'template4')
+        message = prepare_email(self.member, 't:Body')
         self.assertEqual(message.subject, DEFAULT_SUBJECT)
         self.assertEqual(message.body, 'Body')
 
-    @patch('builtins.open', mock_open(read_data='Subject: Custom\nBody'))
     def test_markdown_subject(self):
-        message = prepare_email(self.member, 'template5')
+        message = prepare_email(self.member, 't:Subject: Custom\nBody')
         self.assertEqual(message.subject, 'Custom')
         self.assertEqual(message.body, 'Body')
 
-    @patch('builtins.open', mock_open())
     def test_email_to_no_username(self):
-        message = prepare_email(self.member, 'template6')
+        message = prepare_email(self.member, 't:')
         self.assertEqual(message.to[0], 'member@example.com')
 
-    @patch('builtins.open', mock_open())
     def test_email_to_username(self):
         self.member.username = 'Member Username'
-        message = prepare_email(self.member, 'template7')
+        message = prepare_email(self.member, 't:')
         self.assertEqual(message.to[0], 'Member Username <member@example.com>')
+
+    def test_translation_en(self):
+        message = prepare_email(self.member, 't:{% load i18n %}{% blocktrans %}Translated text{% endblocktrans %}')
+        self.assertEqual(message.body, 'Translated text')
+
+    def test_translation_de(self):
+        self.member.preferences.locale = 'de'
+        # This translation is already provided by Django
+        message = prepare_email(self.member, 't:{% load i18n %}{% blocktrans %}German{% endblocktrans %}')
+        self.assertEqual(message.body, 'Deutsch')

--- a/member/tests.py
+++ b/member/tests.py
@@ -84,10 +84,12 @@ class MemberEmailTest(TestCase):
                 return mock_open(read_data=content).return_value
             return _open(filename, *args, **kw)
 
-        patch('builtins.open', template_open).start()
+        self.patcher = patch('builtins.open', template_open)
+        self.patcher.start()
 
     def tearDown(self):
         Member.objects.all().delete()
+        self.patcher.stop()
 
     def test_markdown_mail(self):
         message = prepare_email(self.member, 't:**Markdown**')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-widget-tweaks==1.4.5
 isort==4.3.21
 Jinja2==2.10.3
 lazy-object-proxy==1.4.3
+markdown==3.2
 MarkupSafe==1.1.1
 mccabe==0.6.1
 pylint==2.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2019.11.28
 Django==3.0
 django-crispy-forms==1.8.1
 django-extensions==2.2.5
+django-q==1.1.0
 django-widget-tweaks==1.4.5
 isort==4.3.21
 Jinja2==2.10.3


### PR DESCRIPTION
An experiment in setting up Django-Q and using it to send email asynchronously.  The Django-Q side was pretty straightforward.  On the email side, I guessed at an architecture that might be useful.  The basic idea is to use Django templates to create Markdown documents, which then produce both the HTML and plain text content of emails.  If the first like of this document begins with 'Subject:', it is taken to be the subject line of the email.  I can already see places where this will probably be insufficient, but I thought I should check in to see if this is going on the right track first.