### PR TITLE
Active status

### DIFF
--- a/agenda/views.py
+++ b/agenda/views.py
@@ -20,12 +20,13 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.decorators import login_required
 from go3.colors import the_colors
 from member.models import MemberPreferences
+from member.util import AgendaChoices
 
 @login_required
 def AgendaSelector(request):
 
     view_selector = {
-        MemberPreferences.AgendaChoices.AGENDA: AgendaView
+        AgendaChoices.AGENDA: AgendaView
     }
 
     return view_selector[request.user.preferences.default_view].as_view()(request)

--- a/band/helpers.py
+++ b/band/helpers.py
@@ -20,6 +20,7 @@ from .models import Band, Assoc, Section
 from gig.helpers import update_plan_default_section
 from member.models import Member
 from django.contrib.auth.decorators import login_required
+from band.util import AssocStatusChoices
 
 @login_required
 def set_assoc_tfparam(request, ak, param, truefalse):
@@ -109,7 +110,7 @@ def join_assoc(request, bk, mk):
         raise PermissionError('tying to create an assoc which is not owned by user {0}'.format(request.user.username))
 
     # OK, create the assoc
-    a = Assoc.objects.get_or_create(band=b, member=m, status=Assoc.StatusChoices.PENDING)
+    a = Assoc.objects.get_or_create(band=b, member=m, status=AssocStatusChoices.PENDING)
 
     return HttpResponse()
 
@@ -139,7 +140,7 @@ def confirm_assoc(request, ak):
         raise PermissionError('tying to confirm an assoc which is not admin by user {0}'.format(request.user.username))
 
     # OK, confirm the assoc
-    a.status = Assoc.StatusChoices.CONFIRMED
+    a.status = AssocStatusChoices.CONFIRMED
     a.save()
 
     return HttpResponse()

--- a/band/util.py
+++ b/band/util.py
@@ -1,0 +1,30 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from django.db import models
+
+class BandStatusChoices(models.IntegerChoices):
+    ACTIVE = 0, "Active"
+    DORMANT = 1, "Dormant"
+    DELETED = 2, "Deleted"
+
+class AssocStatusChoices(models.IntegerChoices):
+    NOT_CONFIRMED = 0, "Not Confirmed"
+    CONFIRMED = 1, "Confirmed"
+    INVITED = 2, "Invited"
+    ALUMNI = 3, "Alumni"
+    PENDING = 4, "Pending"
+

--- a/band/views.py
+++ b/band/views.py
@@ -45,7 +45,7 @@ class UpdateView(LoginRequiredMixin, BaseUpdateView):
 class AllMembersView(LoginRequiredMixin, TemplateView):
     template_name='band/band_all_members.html'
     def get_context_data(self, **kwargs):
-        the_band = self.object
+        the_band = Band.objects.get(id=self.kwargs['pk'])
         context = super().get_context_data(**kwargs)
         context['member_assocs'] = the_band.confirmed_assocs
         return context
@@ -55,12 +55,9 @@ class SectionMembersView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        b = Band.objects.filter(id=self.kwargs['pk'])
+        b = Band.objects.get(id=self.kwargs['pk'])
         # prefetching seems to his the database more
         # b = Band.objects.prefetch_related('assocs').filter(id=self.kwargs['pk'])
-        if len(b) != 1:
-            raise ValueError('getting section info on a band that does not exist')
-        b = b[0]
 
         # make sure I'm in the band or am superuser
         u = self.request.user

--- a/band/views.py
+++ b/band/views.py
@@ -1,11 +1,12 @@
 from django.http import HttpResponse
-from .models import Band, Assoc, Section
 from django.views import generic
 from django.views.generic.edit import UpdateView as BaseUpdateView
 from django.views.generic.base import TemplateView
 from django.urls import reverse
-from .forms import BandForm
 from django.contrib.auth.mixins import LoginRequiredMixin
+from .models import Band, Assoc, Section
+from .forms import BandForm
+from .util import AssocStatusChoices
 
 def index(request):
     return HttpResponse("Hello, world. You're at the band index.")
@@ -27,7 +28,7 @@ class DetailView(generic.DetailView):
             context['the_user_is_associated'] = True
             context['the_user_is_band_admin'] = assoc.is_admin
 
-            context['the_pending_members'] = Assoc.objects.filter(band=the_band, status=Assoc.StatusChoices.PENDING)
+            context['the_pending_members'] = Assoc.objects.filter(band=the_band, status=AssocStatusChoices.PENDING)
         return context
 
     def get_success_url(self):
@@ -80,6 +81,6 @@ class SectionMembersView(LoginRequiredMixin, TemplateView):
 
         context['has_sections'] = True if len(b.sections.all()) > 0 else False
         context['the_section'] = s
-        context['the_assocs'] = b.assocs.filter(status=Assoc.StatusChoices.CONFIRMED, default_section=s, member__is_active=True).all()
+        context['the_assocs'] = b.assocs.filter(status=AssocStatusChoices.CONFIRMED, default_section=s, member__is_active=True).all()
         return context
 

--- a/gig/models.py
+++ b/gig/models.py
@@ -16,6 +16,7 @@
 """
 from django.db import models
 from band.models import Band, Assoc
+from band.util import AssocStatusChoices
 import datetime
 
 class MemberPlanManager(models.Manager):
@@ -25,7 +26,7 @@ class MemberPlanManager(models.Manager):
 
     def future_plans(self, member):
         return super().get_queryset().filter(assoc__member=member, 
-                                             assoc__status=Assoc.StatusChoices.CONFIRMED,
+                                             assoc__status=AssocStatusChoices.CONFIRMED,
                                              gig__schedule_datetime__gt=datetime.datetime.now())
 
 

--- a/member/models.py
+++ b/member/models.py
@@ -18,12 +18,12 @@
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
 from django.contrib.auth.models import User
-from band.models import Band, Assoc
 from motd.models import MOTD
 from gig.models import Plan
 from django.utils.translation import gettext_lazy as _
 import datetime
 from django.utils import timezone
+from .util import MemberStatusChoices, AgendaChoices
 
 class MemberManager(BaseUserManager):
     def _create_user(self, email, password, **extra_fields):
@@ -79,12 +79,8 @@ class Member(AbstractUser):
 
     # flag to determine whether to recompute calendar feed
     cal_feed_dirty = models.BooleanField(default=True)
-    class StatusChoices(models.IntegerChoices):
-        ACTIVE = 0, "Active"
-        DORMANT = 1, "Dormant"
-        DELETED = 2, "Deleted"
 
-    status = models.IntegerField(choices=StatusChoices.choices, default=StatusChoices.ACTIVE)
+    status = models.IntegerField(choices=MemberStatusChoices.choices, default=MemberStatusChoices.ACTIVE)
 
     @property
     def display_name(self):
@@ -158,11 +154,6 @@ class MemberPreferences(models.Model):
     calendar_show_only_committed = models.BooleanField(default=True)
     agenda_show_time = models.BooleanField(default=False)
     show_long_agenda = models.BooleanField(default=True)
-
-    class AgendaChoices(models.IntegerChoices):
-        AGENDA = 0, "Agenda"
-        GRID = 1, "Grid"
-        CALENDAR = 2, "Calendar"
 
     default_view = models.IntegerField(choices=AgendaChoices.choices, default=AgendaChoices.AGENDA)
 

--- a/member/models.py
+++ b/member/models.py
@@ -24,6 +24,7 @@ from django.utils.translation import gettext_lazy as _
 import datetime
 from django.utils import timezone
 from .util import MemberStatusChoices, AgendaChoices
+from band.models import Assoc
 
 class MemberManager(BaseUserManager):
     def _create_user(self, email, password, **extra_fields):

--- a/member/util.py
+++ b/member/util.py
@@ -1,0 +1,28 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from django.db import models
+
+class MemberStatusChoices(models.IntegerChoices):
+    ACTIVE = 0, "Active"
+    DORMANT = 1, "Dormant"
+    DELETED = 2, "Deleted"
+
+class AgendaChoices(models.IntegerChoices):
+    AGENDA = 0, "Agenda"
+    GRID = 1, "Grid"
+    CALENDAR = 2, "Calendar"
+


### PR DESCRIPTION
Added 'status' to members and bands, so they can go dormant. This is a shortcoming of go2 - there's no way to hide a member, or make bands disappear after nobody logs in, etc.

Also some cleanup of how status 'choices' are managed - moved the constants into util files.