### PR TITLE
removed the language from the url processing

### DIFF
--- a/go3/urls.py
+++ b/go3/urls.py
@@ -32,15 +32,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
-from django.conf.urls.i18n import i18n_patterns
 
-urlpatterns = []
-
-urlpatterns += i18n_patterns(
+urlpatterns =[
     path('', include('agenda.urls')),
     path('accounts/', include('django.contrib.auth.urls')),
     path('band/', include('band.urls')),
     path('member/', include('member.urls')),
     path('gig/', include('gig.urls')),
     path('admin/', admin.site.urls),
-)
+]


### PR DESCRIPTION
Django can be set so that the language will be automatically processed into the url like http://site/en/page - which is useful if you want to flip to another language by changing the URL, but not necessary for the gig-o. Was in there for testing; pulled it out.