### PR TITLE
Send new gig email on gig creation

### DIFF
--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -59,3 +59,6 @@ def update_plan_default_section(assoc):
     the default section of the member assoc has changed, so update any plans that aren't overriding
     """
     Plan.objects.filter(assoc=assoc, plan_section=None).update(section=assoc.default_section)
+
+def get_confirm_urls(member, gig):
+    return {'yes_url': 'http://example.com/yes', 'no_url': 'http://example.com/no', 'snooze_url': 'http://example.com/snooze'}

--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -74,7 +74,11 @@ def email_from_plan(plan, template):
                                    if (contact := gig.contact) else ('??', None))
     context = {
         'gig': gig,
+        'change_string': 'FIXME: Figure out what changed',
         'contact_name': contact_name,
+        'status': plan.status,
+        'status_label': Plan.StatusChoices(plan.status).label,
+        **Plan.StatusChoices.__members__,
         **get_confirm_urls(member, gig)
     }
     return prepare_email(member, template, context, reply_to=[contact_email])

--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -81,3 +81,7 @@ def send_emails_from_plans(plans_query, template):
     contactable = plans_query.filter(assoc__status=AssocStatusChoices.CONFIRMED,
                                      assoc__email_me=True)
     send_messages_async(email_from_plan(p, template) for p in contactable)
+
+def send_reminder_email(gig):
+    undecided = gig.member_plans.filter(status__in=(Plan.StatusChoices.NO_PLAN, Plan.StatusChoices.DONT_KNOW))
+    send_emails_from_plans(undecided, 'email/gig_reminder.md')

--- a/gig/models.py
+++ b/gig/models.py
@@ -15,6 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from band.models import Band, Assoc
 from band.util import AssocStatusChoices
 import datetime
@@ -108,6 +109,10 @@ class AbstractGig(models.Model):
     @property
     def is_confirmed(self):
         self.status=StatusOptions.CONFIRMED
+
+    @property
+    def status_string(self):
+        return [_('Unconfirmed'), _('Confirmed!'), _('Cancelled!'), _('Asking')][self.status]
 
     # todo archive
     # archive_id = ndb.TextProperty( default=None )

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -17,6 +17,9 @@
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from .models import Gig, Plan
+from .helpers import get_confirm_urls
+from lib.email import send_messages_async
+from member.helpers import prepare_email
 from datetime import datetime
 from django.utils import timezone
 
@@ -29,6 +32,25 @@ def set_date_time(sender, instance, **kwargs):
 def new_gig_handler(sender, instance, created, **kwargs):
     """ if this is a new gig, make sure there's a plan for every member """
     x = instance.member_plans
+
+@receiver(post_save, sender=Gig)
+def notify_new_gig(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    contact_name, contact_email = ((contact.display_name, contact.email)
+                                   if (contact := instance.contact)
+                                   else ('??', None))
+    emails = [prepare_email(a.member,
+                            'email/new_gig.md',
+                            {
+                                'gig': instance,
+                                'contact_name': contact_name,
+                                **get_confirm_urls(a.member, instance)
+                            },
+                            reply_to=[contact_email])
+              for a in instance.band.confirmed_assocs if a.email_me]
+    send_messages_async(emails)
 
 @receiver(pre_save, sender=Plan)
 def update_plan_section(sender, instance, **kwargs):

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -31,6 +31,8 @@ def notify_new_gig(sender, instance, created, **kwargs):
     if created:
         # This has the side effect of creating plans for all members
         send_emails_from_plans(instance.member_plans, 'email/new_gig.md')
+    else:
+        send_emails_from_plans(instance.member_plans, 'email/edited_gig.md')
 
 @receiver(pre_save, sender=Plan)
 def update_plan_section(sender, instance, **kwargs):

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -117,6 +117,7 @@ class GigTest(TestCase):
         self.assertIn("01/02/2100 (Sat)", message.body)
         self.assertIn('noon (Call Time), 12:30 p.m. (Set Time), 2 p.m. (End Time)', message.body)
         self.assertIn('Unconfirmed', message.body)
+        self.assertNotIn('MISSING', message.subject)
         self.assertNotIn('MISSING', message.body)
 
     def test_new_gig_all_confirmed(self):
@@ -150,6 +151,7 @@ class GigTest(TestCase):
         self.assertIn('12:00 (Beginn), 12:30 (Termin), 14:00 (Ende)', message.body)
         self.assertIn('Nicht fixiert', message.body)
 
+    @override_settings(TEMPLATES=MISSING_TEMPLATES)
     def test_reminder_email(self):
         Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
         g = self.create_gig()
@@ -160,6 +162,8 @@ class GigTest(TestCase):
         message = mail.outbox[0]
         self.assertIn('Reminder', message.subject)
         self.assertIn('reminder', message.body)
+        self.assertNotIn('MISSING', message.subject)
+        self.assertNotIn('MISSING', message.body)
 
     def test_no_reminder_to_decided(self):
         a = Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)

--- a/lib/email.py
+++ b/lib/email.py
@@ -5,7 +5,8 @@ SUBJECT = 'Subject:'
 DEFAULT_SUBJECT = 'Message from Gig-O-Matic'
 
 def send_messages_async(messages):
-    return async_task('lib.email.do_send_messages_async', messages, ack_failure=True)
+    # Can accept an iterable, so we need to make it a list for serialization
+    return async_task('lib.email.do_send_messages_async', list(messages), ack_failure=True)
 
 def do_send_messages_async(messages):
     mail.get_connection().send_messages(messages)

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -42,12 +42,12 @@ def prepare_email(member, template, context=None, **kw):
     context['member'] = member
 
     with translation.override(member.preferences.language):
-        text = render_to_string(template, context)
+        text = render_to_string(template, context).strip()
     if text.startswith(SUBJECT):
         subject, text = [t.strip() for t in text[len(SUBJECT):].split('\n', 1)]
     else:
         subject = DEFAULT_SUBJECT
-    html = markdown(text)
+    html = markdown(text, extensions=['nl2br'])
 
     message = EmailMultiAlternatives(subject, text, to=[member.email_line], **kw)
     message.attach_alternative(html, 'text/html')

--- a/member/tests.py
+++ b/member/tests.py
@@ -118,6 +118,11 @@ class MemberEmailTest(TestCase):
         self.assertEqual(message.subject, 'Custom')
         self.assertEqual(message.body, 'Body')
 
+    def test_markdown_html_escape(self):
+        message = prepare_email(self.member, 't:1 < 2')
+        self.assertIn('<', message.body)
+        self.assertIn('&lt;', message.alternatives[0][0])
+
     def test_email_to_no_username(self):
         message = prepare_email(self.member, 't:')
         self.assertEqual(message.to[0], 'member@example.com')

--- a/member/tests.py
+++ b/member/tests.py
@@ -136,3 +136,14 @@ class MemberEmailTest(TestCase):
         # This translation is already provided by Django
         message = prepare_email(self.member, 't:{% load i18n %}{% blocktrans %}German{% endblocktrans %}')
         self.assertEqual(message.body, 'Deutsch')
+
+    def test_translation_before_subject(self):
+        message = prepare_email(self.member, 't:{% load i18n %}\nSubject: {% blocktrans %}Subject Line{% endblocktrans %}\n\n{% blocktrans %}Body{% endblocktrans %}')
+        self.assertEqual(message.subject, "Subject Line")
+        self.assertEqual(message.body, "Body")
+
+    def test_markdown_new_lines(self):
+        message = prepare_email(self.member, 't:Line one\nLine two')
+        self.assertIn('\n', message.body)
+        # We want a new line, but it could show up as "<br>" or "<br />"
+        self.assertIn('<br', message.alternatives[0][0])

--- a/templates/email/edited_gig.md
+++ b/templates/email/edited_gig.md
@@ -1,0 +1,8 @@
+{% extends "email/gig.md" %}
+{% load i18n %}
+
+{% block subject %}{% blocktrans with gig.title as gig_title %}Gig Edit ({{ change_string }}) {{ gig_title }}{% endblocktrans %}{% endblock %}
+
+{% block opening %}{% blocktrans with band_name=gig.band.name %}Hello! A gig has been edited in the Gig-o-Matic for your band {{ band_name }}:{% endblocktrans %}
+
+{% trans "EDITED" %}: {{ change_string }}{% endblock %}

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n %}{% autoescape off %}
 Subject: {% block subject %}{% endblock %}
 
 {% block opening %}{% endblock %}
@@ -22,4 +22,4 @@ If you **aren't sure** and want to be reminded in a few days, [click here]({{ sn
 {% blocktrans %}Gig info page is [here](https://gig-o-matic.com{{ gig_url }}).{% endblocktrans %}
 
 {% blocktrans %}Thanks,
-The Gig-o-Matic Team{% endblocktrans %}
+The Gig-o-Matic Team{% endblocktrans %}{% endautoescape %}

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -12,12 +12,14 @@ Subject: {% block subject %}{% endblock %}
 {{ gig.details }}
 {% endif %}{% if gig.setlist %}
 {{ gig.setlist }}
+{% endif %}{% if status != NO_PLAN and status != DONT_KNOW %}
+{% blocktrans %}Your current status is {{ status_label }}.  If that is still correct, you need not take any action.{% endblocktrans %}
+{% endif %}{% if status != DEFINITELY %}
+{% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).{% endblocktrans %}
+{% endif %}{% if status != CANT_DO_IT %}
+{% blocktrans %}If you **can't** make it, [click here]({{ no_url }}).{% endblocktrans %}
 {% endif %}
-{% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).
-
-If you **can't** make it, [click here]({{ no_url }}).
-
-If you **aren't sure** and want to be reminded in a few days, [click here]({{ snooze_url }}).{% endblocktrans %}
+{% blocktrans %}If you **aren't sure** and want to be reminded in a few days, [click here]({{ snooze_url }}).{% endblocktrans %}
 {% url 'gig-detail' gig.id as gig_url %}
 {% blocktrans %}Gig info page is [here](https://gig-o-matic.com{{ gig_url }}).{% endblocktrans %}
 

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -1,0 +1,25 @@
+{% load i18n %}
+Subject: {% block subject %}{% endblock %}
+
+{% block opening %}{% endblock %}
+
+{{ gig.title }}
+{% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.enddate %} - {{ gig.enddate|date:"SHORT_DATE_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
+{% trans "Time" %}: {% if gig.calltime %}{{ gig.calltime|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.settime or gig.endtime %}, {% endif %}{% endif %}{% if gig.settime %}{{ gig.settime|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.endtime %}, {% endif %}{% endif %}{% if gig.endtime %}{{ gig.endtime|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
+{% trans "Contact" %}: {{ contact_name }}
+{% trans "Status" %}: {{ gig.status_string }}
+{% if gig.details %}
+{{ gig.details }}
+{% endif %}{% if gig.setlist %}
+{{ gig.setlist }}
+{% endif %}
+{% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).
+
+If you **can't** make it, [click here]({{ no_url }}).
+
+If you **aren't sure** and want to be reminded in a few days, [click here]({{ snooze_url }}).{% endblocktrans %}
+{% url 'gig-detail' gig.id as gig_url %}
+{% blocktrans %}Gig info page is [here](https://gig-o-matic.com{{ gig_url }}).{% endblocktrans %}
+
+{% blocktrans %}Thanks,
+The Gig-o-Matic Team{% endblocktrans %}

--- a/templates/email/gig_reminder.md
+++ b/templates/email/gig_reminder.md
@@ -1,0 +1,6 @@
+{% extends "email/gig.md" %}
+{% load i18n %}
+
+{% block subject %}{% blocktrans %}Gig Reminder: {{ gig.title }}{% endblocktrans %}{% endblock %}
+
+{% block opening %}{% blocktrans with band_name=gig.band.name %}Hello! Just a reminder to weigh in on a gig for your band {{ band_name }}:{% endblocktrans %}{% endblock %}

--- a/templates/email/gig_reminder.md
+++ b/templates/email/gig_reminder.md
@@ -1,6 +1,6 @@
 {% extends "email/gig.md" %}
 {% load i18n %}
 
-{% block subject %}{% blocktrans %}Gig Reminder: {{ gig.title }}{% endblocktrans %}{% endblock %}
+{% block subject %}{% blocktrans with gig.title as gig_title %}Gig Reminder: {{ gig_title }}{% endblocktrans %}{% endblock %}
 
 {% block opening %}{% blocktrans with band_name=gig.band.name %}Hello! Just a reminder to weigh in on a gig for your band {{ band_name }}:{% endblocktrans %}{% endblock %}

--- a/templates/email/new_gig.md
+++ b/templates/email/new_gig.md
@@ -1,6 +1,6 @@
 {% extends "email/gig.md" %}
 {% load i18n %}
 
-{% block subject %}{% blocktrans %}New Gig: {{ gig.title }}{% endblocktrans %}{% endblock %}
+{% block subject %}{% blocktrans with gig.title as gig_title %}New Gig: {{ gig_title }}{% endblocktrans %}{% endblock %}
 
 {% block opening %}{% blocktrans with band_name=gig.band.name %}Hello! A new gig has been added to the Gig-o-Matic for your band {{ band_name }}:{% endblocktrans %}{% endblock %}

--- a/templates/email/new_gig.md
+++ b/templates/email/new_gig.md
@@ -1,25 +1,6 @@
+{% extends "email/gig.md" %}
 {% load i18n %}
-Subject: {% blocktrans %}New Gig: {{ gig.title }}{% endblocktrans %}
 
-{% blocktrans with band_name=gig.band.name %}Hello! A new gig has been added to the Gig-o-Matic for your band {{ band_name }}:{% endblocktrans %}
+{% block subject %}{% blocktrans %}New Gig: {{ gig.title }}{% endblocktrans %}{% endblock %}
 
-{{ gig.title }}
-{% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.enddate %} - {{ gig.enddate|date:"SHORT_DATE_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
-{% trans "Time" %}: {% if gig.calltime %}{{ gig.calltime|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.settime or gig.endtime %}, {% endif %}{% endif %}{% if gig.settime %}{{ gig.settime|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.endtime %}, {% endif %}{% endif %}{% if gig.endtime %}{{ gig.endtime|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
-{% trans "Contact" %}: {{ contact_name }}
-{% trans "Status" %}: {{ gig.status_string }}
-{% if gig.details %}
-{{ gig.details }}
-{% endif %}{% if gig.setlist %}
-{{ gig.setlist }}
-{% endif %}
-{% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).
-
-If you **can't** make it, [click here]({{ no_url }}).
-
-If you **aren't sure** and want to be reminded in a few days, [click here]({{ snooze_url }}).{% endblocktrans %}
-{% url 'gig-detail' gig.id as gig_url %}
-{% blocktrans %}Gig info page is [here](https://gig-o-matic.com{{ gig_url }}).{% endblocktrans %}
-
-{% blocktrans %}Thanks,
-The Gig-o-Matic Team{% endblocktrans %}
+{% block opening %}{% blocktrans with band_name=gig.band.name %}Hello! A new gig has been added to the Gig-o-Matic for your band {{ band_name }}:{% endblocktrans %}{% endblock %}

--- a/templates/email/new_gig.md
+++ b/templates/email/new_gig.md
@@ -1,0 +1,25 @@
+{% load i18n %}
+Subject: {% blocktrans %}New Gig: {{ gig.title }}{% endblocktrans %}
+
+{% blocktrans with band_name=gig.band.name %}Hello! A new gig has been added to the Gig-o-Matic for your band {{ band_name }}:{% endblocktrans %}
+
+{{ gig.title }}
+{% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.enddate %} - {{ gig.enddate|date:"SHORT_DATE_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
+{% trans "Time" %}: {% if gig.calltime %}{{ gig.calltime|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.settime or gig.endtime %}, {% endif %}{% endif %}{% if gig.settime %}{{ gig.settime|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.endtime %}, {% endif %}{% endif %}{% if gig.endtime %}{{ gig.endtime|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
+{% trans "Contact" %}: {{ contact_name }}
+{% trans "Status" %}: {{ gig.status_string }}
+{% if gig.details %}
+{{ gig.details }}
+{% endif %}{% if gig.setlist %}
+{{ gig.setlist }}
+{% endif %}
+{% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).
+
+If you **can't** make it, [click here]({{ no_url }}).
+
+If you **aren't sure** and want to be reminded in a few days, [click here]({{ snooze_url }}).{% endblocktrans %}
+{% url 'gig-detail' gig.id as gig_url %}
+{% blocktrans %}Gig info page is [here](https://gig-o-matic.com{{ gig_url }}).{% endblocktrans %}
+
+{% blocktrans %}Thanks,
+The Gig-o-Matic Team{% endblocktrans %}

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -25,36 +25,36 @@
             {{ form.errors }}
 
             <div class="form-group">
-                {{ form.title.errore }}
+                {{ form.title.errors }}
                 {{ form.title.label_tag }}
                 {% render_field form.title class="form-control" %}
             </div>
             <div class="row">
                 <div class="form-group col-6">
-                    {{ form.contact.errore }}
+                    {{ form.contact.errors }}
                     {{ form.contact.label_tag }}
                     {% render_field form.contact class="form-control" %}
                 </div>
                 <div class="form-group col-6">
-                    {{ form.status.errore }}
+                    {{ form.status.errors }}
                     {{ form.status.label_tag }}
                     {% render_field form.status class="form-control" %}
                 </div>
             </div>
             <div class="form-group">
-                {{ form.is_private.errore }}
+                {{ form.is_private.errors }}
                 {% render_field form.is_private %}
                 {{ form.is_private.label_tag }}
             </div>
              
             <div class="row">
                 <div class="form-group col-4">
-                    {{ form.date.errore }}
+                    {{ form.date.errors }}
                     {{ form.date.label_tag }}
                     {% render_field form.date class="form-control" %}
                 </div>
                 <div class="form-group col-4">
-                    {{ form.enddate.errore }}
+                    {{ form.enddate.errors }}
                     {{ form.enddate.label_tag }}
                     {% render_field form.enddate class="form-control" %}
                 </div>


### PR DESCRIPTION
It's still in a rough form, but the basics work.  Hopefully this is enough to see if we're on the right track or not.  A few comments:

- There's a fake get_confirm_urls function as a placeholder, since I don't see anything around this functionality currently implemented.
- Much of this should generalize to also handle reminder emails and change emails, but I haven't done any work in that direction.  I'd rather see how this develops before figuring out the right places to generalize.
- A lot of the display logic has been moved into the template itself.  Since the template rendering is happening in the member's locale, this means we can get dates and times automatically localized, without functions like format_date_for_member.  The downside is that the Django templates don't seem to have an option to control whitespace before or after tags (as Jinga templates do), making the template a bit difficult to read.  We might be able to address this with some custom filters, but it's not all that bad as-is.