### PR TITLE
Add async_receiver decorator, to trigger async task on signals

### DIFF
--- a/gig/signals.py
+++ b/gig/signals.py
@@ -18,6 +18,7 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from .models import Gig, Plan
 from gig.helpers import send_emails_from_plans
+from lib.asyncsignal import async_receiver
 from datetime import datetime
 from django.utils import timezone
 
@@ -26,7 +27,7 @@ def set_date_time(sender, instance, **kwargs):
     t = instance.schedule_time
     instance.schedule_datetime = datetime.combine(instance.schedule_date, t) if t else instance.schedule_date
 
-@receiver(post_save, sender=Gig)
+@async_receiver(post_save, sender=Gig)
 def notify_new_gig(sender, instance, created, **kwargs):
     if created:
         # This has the side effect of creating plans for all members

--- a/lib/asyncsignal.py
+++ b/lib/asyncsignal.py
@@ -1,0 +1,21 @@
+from functools import wraps
+from django.dispatch import receiver
+from django_q.tasks import async_task
+
+def async_receiver(*args, **kw):
+    """Decorator to register a signal hander to run as an async_task.
+
+    Accepts the same arguments at django.dispatch.receiver.  The decorated function
+    will get all of the same arguments as it would running synchronously, except
+    for the signal."""
+
+    def decorator(func):
+        @wraps(func)
+        def decorated(*fargs, is_async=False, signal=None, **fkw):
+            # signal cannot be pickled, so we don't pass it into the async task
+            if is_async:
+                return func(*fargs, **fkw)
+            else:
+                return async_task(decorated, *fargs, is_async=True, **fkw)
+        return receiver(*args, **kw)(decorated)
+    return decorator


### PR DESCRIPTION
Here was a little experiment I made in #25.  It creates an `async_receiver` decorator that causes an async task to run on signal reception.  For testing purposes, I stuck it on the `notify_new_gig` handler.  This leads to two questions:

1. Should `notify_new_gig` run async?  The really slow part, email sending, is already in an async task.  But I could imagine that prepping all the emails for a large band could bog down too.  There's no need to do it synchronously, so I think it's worthwhile.

2. Do we need a new decorator for this?  If this is the only place we need it, it'd be simpler to just trigger an async task by hand.  But if this becomes a common pattern, the decorator would be useful.  I don't really know what to expect in the future development.