### PR TITLE
Some clean-up tasks

### DIFF
--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -88,6 +88,9 @@ def send_emails_from_plans(plans_query, template):
                                      assoc__email_me=True)
     send_messages_async(email_from_plan(p, template) for p in contactable)
 
+def send_email_from_gig(gig, template):
+    send_emails_from_plans(gig.member_plans, template)
+
 def send_reminder_email(gig):
     undecided = gig.member_plans.filter(status__in=(Plan.StatusChoices.NO_PLAN, Plan.StatusChoices.DONT_KNOW))
     send_emails_from_plans(undecided, 'email/gig_reminder.md')

--- a/gig/models.py
+++ b/gig/models.py
@@ -37,13 +37,13 @@ class Plan(models.Model):
     assoc = models.ForeignKey("band.Assoc", verbose_name="assoc", related_name="plans", on_delete=models.CASCADE)
 
     class StatusChoices(models.IntegerChoices):
-        NO_PLAN = 0, "No Plan"
-        DEFINITELY = 1, "Definitely"
-        PROBABLY = 2, "Probably"
-        DONT_KNOW = 3, "Don't Know"
-        PROBABLY_NOT = 4, "Probably Not"
-        CANT_DO_IT = 5, "Can't Do It"
-        NOT_INTERESTED = 6, "Not Interested"
+        NO_PLAN = 0, _("No Plan")
+        DEFINITELY = 1, _("Definitely")
+        PROBABLY = 2, _("Probably")
+        DONT_KNOW = 3, _("Don't Know")
+        PROBABLY_NOT = 4, _("Probably Not")
+        CANT_DO_IT = 5, _("Can't Do It")
+        NOT_INTERESTED = 6, _("Not Interested")
 
     status = models.IntegerField(choices=StatusChoices.choices, default=StatusChoices.NO_PLAN)
 

--- a/gig/models.py
+++ b/gig/models.py
@@ -38,8 +38,8 @@ class Plan(models.Model):
 
     class StatusChoices(models.IntegerChoices):
         NO_PLAN = 0, _("No Plan")
-        DEFINITELY = 1, _("Definitely")
-        PROBABLY = 2, _("Probably")
+        DEFINITELY = 1, _("Definite")
+        PROBABLY = 2, _("Probable")
         DONT_KNOW = 3, _("Don't Know")
         PROBABLY_NOT = 4, _("Probably Not")
         CANT_DO_IT = 5, _("Can't Do It")

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -28,11 +28,8 @@ def set_date_time(sender, instance, **kwargs):
 
 @receiver(post_save, sender=Gig)
 def notify_new_gig(sender, instance, created, **kwargs):
-    if created:
-        # This has the side effect of creating plans for all members
-        send_emails_from_plans(instance.member_plans, 'email/new_gig.md')
-    else:
-        send_emails_from_plans(instance.member_plans, 'email/edited_gig.md')
+    # This has the side effect of creating plans for all members
+    send_emails_from_plans(instance.member_plans, 'email/new_gig.md' if created else 'email/edited_gig.md')
 
 @receiver(pre_save, sender=Plan)
 def update_plan_section(sender, instance, **kwargs):

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -236,7 +236,7 @@ class GigTest(TestCase):
         g.save()
 
         message = mail.outbox[0]
-        self.assertIn(f'Your current status is {Plan.StatusChoices.DEFINITELY.label}', message.body)
+        self.assertIn(f'Your current status is "{Plan.StatusChoices.DEFINITELY.label}"', message.body)
         self.assertNotIn('**can** make it', message.body)
         self.assertIn("**can't** make it", message.body)
 
@@ -249,6 +249,6 @@ class GigTest(TestCase):
         g.save()
 
         message = mail.outbox[0]
-        self.assertIn(f'Your current status is {Plan.StatusChoices.CANT_DO_IT.label}', message.body)
+        self.assertIn(f'Your current status is "{Plan.StatusChoices.CANT_DO_IT.label}"', message.body)
         self.assertIn('**can** make it', message.body)
         self.assertNotIn("**can't** make it", message.body)

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -13,7 +13,7 @@ Subject: {% block subject %}{% endblock %}
 {% endif %}{% if gig.setlist %}
 {{ gig.setlist }}
 {% endif %}{% if status != NO_PLAN and status != DONT_KNOW %}
-{% blocktrans %}Your current status is {{ status_label }}.  If that is still correct, you need not take any action.{% endblocktrans %}
+{% blocktrans %}Your current status is "{{ status_label }}".  If that is still correct, you need not take any action.{% endblocktrans %}
 {% endif %}{% if status != DEFINITELY %}
 {% blocktrans %}If you **can** make it, [click here]({{ yes_url }}).{% endblocktrans %}
 {% endif %}{% if status != CANT_DO_IT %}


### PR DESCRIPTION
A couple of small things.  I can split them into separate PRs if you prefer.
- Move gig email prep to async (#29).
- Make status choices translatable
- Change status choice working to fit better in gig email.