### PR TITLE
Improve display of gig times in gig emails

### DIFF
--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -103,6 +103,12 @@ def generate_changes(latest, previous):
         changes.append((_('Details'), _('(See below.)'), None))
     return changes
 
+def is_single_day(gig):
+    end = gig.enddate or gig.setdate
+    if not end:
+        return True
+    return (end - gig.date) < datetime.timedelta(days=1)
+
 def email_from_plan(plan, template):
     gig = plan.gig
     with timezone.override(gig.band.timezone):
@@ -115,6 +121,7 @@ def email_from_plan(plan, template):
             'gig': gig,
             'changes': changes,
             'changes_title': join_trans(_(', '), (c[0] for c in changes)),
+            'single_day': is_single_day(gig),
             'contact_name': contact_name,
             'plan': plan,
             'status': plan.status,

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -144,15 +144,30 @@ class GigTest(TestCase):
 
     def test_gig_time_no_set(self):
         self.assoc_joe_and_create_gig(set_date=None)
-        self.assertIn('Time: noon (Call Time), 2 p.m. (End Time)\n', mail.outbox[0].body)
+        self.assertIn('Time: noon (Call Time), 2 p.m. (End Time)\nContact', mail.outbox[0].body)
 
     def test_gig_time_no_end(self):
         self.assoc_joe_and_create_gig(end_date=None)
-        self.assertIn('Time: noon (Call Time), 12:30 p.m. (Set Time)\n', mail.outbox[0].body)
+        self.assertIn('Time: noon (Call Time), 12:30 p.m. (Set Time)\nContact', mail.outbox[0].body)
 
     def test_gig_time_no_set_no_end(self):
         self.assoc_joe_and_create_gig(set_date=None, end_date=None)
-        self.assertIn('Time: noon (Call Time)\n', mail.outbox[0].body)
+        self.assertIn('Time: noon (Call Time)\nContact', mail.outbox[0].body)
+
+    def test_gig_time_long_set(self):
+        date = timezone.datetime(2100, 1, 2, 12, tzinfo=pytz_timezone(self.band.timezone))
+        self.assoc_joe_and_create_gig(start_date=date, set_date=date + timedelta(days=1), end_date=None)
+        self.assertIn('Call Time: 01/02/2100 noon (Sat)\nSet Time: 01/03/2100 noon (Sun)\nContact', mail.outbox[0].body)
+
+    def test_gig_time_long_end(self):
+        date = timezone.datetime(2100, 1, 2, 12, tzinfo=pytz_timezone(self.band.timezone))
+        self.assoc_joe_and_create_gig(start_date=date, set_date=None, end_date=date + timedelta(days=1))
+        self.assertIn('Call Time: 01/02/2100 noon (Sat)\nEnd Time: 01/03/2100 noon (Sun)\nContact', mail.outbox[0].body)
+
+    def test_gig_time_long_set_end(self):
+        date = timezone.datetime(2100, 1, 2, 12, tzinfo=pytz_timezone(self.band.timezone))
+        self.assoc_joe_and_create_gig(start_date=date, set_date=date + timedelta(days=1), end_date=date+timedelta(days=1, hours=1))
+        self.assertIn('Call Time: 01/02/2100 noon (Sat)\nSet Time: 01/03/2100 noon (Sun)\nEnd Time: 01/03/2100 1 p.m. (Sun)\nContact', mail.outbox[0].body)
 
     def test_new_gig_contact(self):
         Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -47,11 +47,11 @@ class GigTest(TestCase):
         Assoc.objects.all().delete()
 
     def create_gig(self, start_date='auto', set_date='auto', end_date='auto'):
-        thedate = timezone.datetime(2100,1,2, 12, tzinfo=pytz_timezone(self.band.timezone))
+        thedate = timezone.datetime(2100,1,2, 12, tzinfo=pytz_timezone(self.band.timezone)) if start_date == 'auto' else start_date
         return Gig.objects.create(
             title="New Gig",
             band_id=self.band.id,
-            date=thedate if start_date == 'auto' else start_date,
+            date=thedate,
             setdate=thedate + timedelta(minutes=30) if set_date == 'auto' else set_date,
             enddate=thedate + timedelta(hours=2) if end_date == 'auto' else end_date,
         )
@@ -192,8 +192,8 @@ class GigTest(TestCase):
         self.joeuser.save()
         self.band.timezone = 'America/New_York'
         self.band.save()
-        Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
-        g = self.create_gig()
+        date = timezone.datetime(2100, 1, 2, 12, tzinfo=pytz_timezone('UTC'))
+        self.assoc_joe_and_create_gig(start_date=date)
         self.assertEqual(len(mail.outbox), 1)
         message = mail.outbox[0]
         self.assertIn("01/02/2100 (Sat)", message.body)

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -3,10 +3,14 @@ Subject: {% block subject %}{% endblock %}
 
 {% block opening %}{% endblock %}
 
-{{ gig.title }}
-{% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.enddate %} - {{ gig.enddate|date:"SHORT_DATE_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
+{{ gig.title }}{% if single_day %}
+{% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }})
 {% trans "Time" %}: {{ gig.date|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.setdate or gig.enddate %}, {% endif %}{% if gig.setdate %}{{ gig.setdate|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.enddate %}, {% endif %}{% endif %}{% if gig.enddate %}{{ gig.enddate|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
-{% trans "Contact" %}: {{ contact_name }}
+{% else %}
+{% trans "Call Time" %}: {{ gig.date|date:"SHORT_DATETIME_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.setdate %}
+{% trans "Set Time" %}: {{ gig.setdate|date:"SHORT_DATETIME_FORMAT" }} ({{ gig.setdate|date:"D" }}){% endif %}{% if gig.enddate %}
+{% trans "End Time" %}: {{ gig.enddate|date:"SHORT_DATETIME_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
+{% endif %}{% trans "Contact" %}: {{ contact_name }}
 {% trans "Status" %}: {{ gig.status_string }}
 {% if gig.details %}
 {{ gig.details }}

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -5,7 +5,7 @@ Subject: {% block subject %}{% endblock %}
 
 {{ gig.title }}
 {% trans "Date" %}: {{ gig.date|date:"SHORT_DATE_FORMAT" }} ({{ gig.date|date:"D" }}){% if gig.enddate %} - {{ gig.enddate|date:"SHORT_DATE_FORMAT" }} ({{ gig.enddate|date:"D" }}){% endif %}
-{% trans "Time" %}: {% if gig.date %}{{ gig.date|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.setdate or gig.enddate %}, {% endif %}{% endif %}{% if gig.setdate %}{{ gig.setdate|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.enddate %}, {% endif %}{% endif %}{% if gig.enddate %}{{ gig.enddate|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
+{% trans "Time" %}: {{ gig.date|time:"TIME_FORMAT" }} ({% trans "Call Time" %}){% if gig.setdate or gig.enddate %}, {% endif %}{% if gig.setdate %}{{ gig.setdate|time:"TIME_FORMAT" }} ({% trans "Set Time" %}){% if gig.enddate %}, {% endif %}{% endif %}{% if gig.enddate %}{{ gig.enddate|time:"TIME_FORMAT" }} ({% trans "End Time" %}){% endif %}
 {% trans "Contact" %}: {{ contact_name }}
 {% trans "Status" %}: {{ gig.status_string }}
 {% if gig.details %}


### PR DESCRIPTION
This follows the discussion in #37.  I use `SHORT_DATETIME_FORMAT` to display the date and time together, but in English this produces strings of the form "01/02/2100 noon".  I think it would look better the other way around, but I'm not sure the best way to do that.  I think we can redefine `SHORT_DATETIME_FORMAT`, but I don't know if we can do that for all of the translations.  We could also just pass our own custom format in (which would allow us to include the day in a single formatting), but I don't know how translations work there either.  I'll investigate, but if you know about such things, I'm happy to hear.

These changes made fix 2 for #44 relatively easy, although I'm still not sure that's what we mean to be testing.