### PR TITLE
Gig template

### DIFF
--- a/band/models.py
+++ b/band/models.py
@@ -20,6 +20,7 @@ from django.db.models import Q
 from go3.colors import the_colors
 from .util import BandStatusChoices, AssocStatusChoices
 from member.util import MemberStatusChoices, AgendaChoices
+from django.apps import apps
 
 class Band(models.Model):
     name = models.CharField(max_length=200)
@@ -78,6 +79,10 @@ class Band(models.Model):
     @property
     def confirmed_assocs(self):
         return self.assocs.filter(status=AssocStatusChoices.CONFIRMED, member__status=MemberStatusChoices.ACTIVE)
+
+    @property
+    def confirmed_members(self):
+        return apps.get_model('member','Member').objects.filter(assocs__status=AssocStatusChoices.CONFIRMED, assocs__band=self, status=MemberStatusChoices.ACTIVE)
 
     def __str__(self):
         return self.name

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -63,8 +63,10 @@ class GigForm(forms.ModelForm):
 
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('required')}),
-            'address': forms.TextInput(attrs={'placeholder': _('location_placeholder')}),
+            'address': forms.TextInput(attrs={'placeholder': _('Cloudcuckooland')}),
             'dress': forms.TextInput(attrs={'placeholder': _('Pants Optional')}),
             'paid': forms.TextInput(attrs={'placeholder': _('As If')}),
-            'postgig': forms.TextInput(attrs={'placeholder': _('postgig_placeholder')})
+            'postgig': forms.TextInput(attrs={'placeholder': _('Hit the streets!')}),
+            'details': forms.Textarea(attrs={'placeholder': _('who? what? where? when? why?')}),
+            'setlist': forms.Textarea(attrs={'placeholder': _('setlist here')}),
         }

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -25,11 +25,18 @@ from django.utils.translation import gettext_lazy as _
 class GigForm(forms.ModelForm):
     def __init__(self, **kwargs):
         band = kwargs.pop('band', None)
+<<<<<<< HEAD
         user = kwargs.pop('user', None)
+=======
+>>>>>>> set gig form so it has an appropriate queryset for contact and leader
         super().__init__(
             label_suffix='',
             **kwargs
         )
+        if band:
+            self.fields['contact'].queryset = band.confirmed_members
+            self.fields['leader'].queryset = band.confirmed_members
+
 
         if user:
             self.fields['contact'].initial = user

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -47,6 +47,7 @@ class GigForm(forms.ModelForm):
             self.fields['leader'].queryset = band.confirmed_members
 
     def clean(self):
+        self.tmp_send_update = self.cleaned_data['send_update']
         date = self.cleaned_data['date']
         if date < timezone.now():
             self.add_error('date', ValidationError(_('Gig call time must be in the future'), code='invalid date'))
@@ -62,10 +63,11 @@ class GigForm(forms.ModelForm):
 
         super().clean()
 
+    send_update = forms.BooleanField(required=False)
     class Meta:
         model = Gig
         fields = ['title','contact','status','is_private','date','setdate','enddate','address','dress','paid','leader', 'postgig',
-                'details','setlist','rss_description','invite_occasionals','hide_from_calendar']
+                'details','setlist','rss_description','invite_occasionals','hide_from_calendar','send_update']
 
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('required')}),

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -46,9 +46,13 @@ class GigForm(forms.ModelForm):
 
     class Meta:
         model = Gig
-        fields = ['title','contact','status','is_private','date','setdate','enddate','address','dress','paid','postgig',
+        fields = ['title','contact','status','is_private','date','setdate','enddate','address','dress','paid','leader', 'postgig',
                 'details','setlist','rss_description','invite_occasionals','hide_from_calendar']
 
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('required')}),
+            'address': forms.TextInput(attrs={'placeholder': _('location_placeholder')}),
+            'dress': forms.TextInput(attrs={'placeholder': _('Pants Optional')}),
+            'paid': forms.TextInput(attrs={'placeholder': _('As If')}),
+            'postgig': forms.TextInput(attrs={'placeholder': _('postgig_placeholder')}),
         }

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -25,18 +25,11 @@ from django.utils.translation import gettext_lazy as _
 class GigForm(forms.ModelForm):
     def __init__(self, **kwargs):
         band = kwargs.pop('band', None)
-<<<<<<< HEAD
         user = kwargs.pop('user', None)
-=======
->>>>>>> set gig form so it has an appropriate queryset for contact and leader
         super().__init__(
             label_suffix='',
             **kwargs
         )
-        if band:
-            self.fields['contact'].queryset = band.confirmed_members
-            self.fields['leader'].queryset = band.confirmed_members
-
 
         if user:
             self.fields['contact'].initial = user
@@ -44,8 +37,6 @@ class GigForm(forms.ModelForm):
         if band:
             self.fields['contact'].queryset = band.confirmed_members
             self.fields['leader'].queryset = band.confirmed_members
-
-
 
     def clean(self):
         date = self.cleaned_data['date']

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -47,7 +47,6 @@ class GigForm(forms.ModelForm):
             self.fields['leader'].queryset = band.confirmed_members
 
     def clean(self):
-        self.tmp_send_update = self.cleaned_data['send_update']
         date = self.cleaned_data['date']
         if date < timezone.now():
             self.add_error('date', ValidationError(_('Gig call time must be in the future'), code='invalid date'))
@@ -64,6 +63,12 @@ class GigForm(forms.ModelForm):
         super().clean()
 
     send_update = forms.BooleanField(required=False)
+
+    # def is_valid(self):
+    #     if self.cleaned_data['send_update']:
+    #         send_gig_announcements(self)
+    #     return super().is_valid()
+
     class Meta:
         model = Gig
         fields = ['title','contact','status','is_private','date','setdate','enddate','address','dress','paid','leader', 'postgig',

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -30,6 +30,10 @@ class GigForm(forms.ModelForm):
             label_suffix='',
             **kwargs
         )
+
+        if user:
+            self.fields['contact'].initial = user
+            self.fields['contact'].empty_label = None
         if band:
             self.fields['contact'].queryset = band.confirmed_members
             self.fields['leader'].queryset = band.confirmed_members

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -64,11 +64,6 @@ class GigForm(forms.ModelForm):
 
     send_update = forms.BooleanField(required=False)
 
-    # def is_valid(self):
-    #     if self.cleaned_data['send_update']:
-    #         send_gig_announcements(self)
-    #     return super().is_valid()
-
     class Meta:
         model = Gig
         fields = ['title','contact','status','is_private','date','setdate','enddate','address','dress','paid','leader', 'postgig',

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -38,14 +38,6 @@ class GigForm(forms.ModelForm):
             self.fields['contact'].queryset = band.confirmed_members
             self.fields['leader'].queryset = band.confirmed_members
 
-
-        if user:
-            self.fields['contact'].initial = user
-            self.fields['contact'].empty_label = None
-        if band:
-            self.fields['contact'].queryset = band.confirmed_members
-            self.fields['leader'].queryset = band.confirmed_members
-
     def clean(self):
         date = self.cleaned_data['date']
         if date < timezone.now():

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -30,6 +30,10 @@ class GigForm(forms.ModelForm):
             label_suffix='',
             **kwargs
         )
+        if band:
+            self.fields['contact'].queryset = band.confirmed_members
+            self.fields['leader'].queryset = band.confirmed_members
+
 
         if user:
             self.fields['contact'].initial = user

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -17,16 +17,22 @@
 
 from django import forms
 from .models import Gig
+from band.models import Band
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 class GigForm(forms.ModelForm):
     def __init__(self, **kwargs):
+        band = kwargs.pop('band', None)
         super().__init__(
             label_suffix='',
             **kwargs
         )
+        if band:
+            self.fields['contact'].queryset = band.confirmed_members
+            self.fields['leader'].queryset = band.confirmed_members
+
 
     def clean(self):
         date = self.cleaned_data['date']
@@ -54,5 +60,5 @@ class GigForm(forms.ModelForm):
             'address': forms.TextInput(attrs={'placeholder': _('location_placeholder')}),
             'dress': forms.TextInput(attrs={'placeholder': _('Pants Optional')}),
             'paid': forms.TextInput(attrs={'placeholder': _('As If')}),
-            'postgig': forms.TextInput(attrs={'placeholder': _('postgig_placeholder')}),
+            'postgig': forms.TextInput(attrs={'placeholder': _('postgig_placeholder')})
         }

--- a/gig/forms.py
+++ b/gig/forms.py
@@ -25,13 +25,19 @@ from django.utils.translation import gettext_lazy as _
 class GigForm(forms.ModelForm):
     def __init__(self, **kwargs):
         band = kwargs.pop('band', None)
+        user = kwargs.pop('user', None)
         super().__init__(
             label_suffix='',
             **kwargs
         )
+
+        if user:
+            self.fields['contact'].initial = user
+            self.fields['contact'].empty_label = None
         if band:
             self.fields['contact'].queryset = band.confirmed_members
             self.fields['leader'].queryset = band.confirmed_members
+
 
 
     def clean(self):

--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -159,6 +159,5 @@ def send_snooze_reminders():
     unsnooze.update(snooze_until=None)
 
 def notify_new_gig(gig, created):
-    # This will have the side effect of creating plans for all members
     async_task('gig.helpers.send_email_from_gig', gig,
                'email/new_gig.md' if created else 'email/edited_gig.md')

--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -27,6 +27,8 @@ from band.models import Section, AssocStatusChoices
 from member.helpers import prepare_email
 from lib.email import send_messages_async
 from lib.translation import join_trans
+from django_q.tasks import async_task
+
 
 @login_required
 def update_plan(request, pk, val):
@@ -155,3 +157,8 @@ def send_snooze_reminders():
                                    gig__date__gt=now)
     send_emails_from_plans(unsnooze, 'email/gig_reminder.md')
     unsnooze.update(snooze_until=None)
+
+def notify_new_gig(gig, created):
+    # This will have the side effect of creating plans for all members
+    async_task('gig.helpers.send_email_from_gig', gig,
+               'email/new_gig.md' if created else 'email/edited_gig.md')

--- a/gig/models.py
+++ b/gig/models.py
@@ -94,10 +94,10 @@ class AbstractGig(models.Model):
 
     address = models.TextField(null=True, blank=True)
     class StatusOptions(models.IntegerChoices):
-            UNKNOWN = 0
-            CONFIRMED = 1
-            CANCELLED = 2
-            ASKING = 3
+            UNKNOWN = 0, _("Unknown")
+            CONFIRMED = 1, _("Confirmed")
+            CANCELLED = 2, _("Cancelled")
+            ASKING = 3, _("Asking")
     status = models.IntegerField(choices=StatusOptions.choices, default=StatusOptions.UNKNOWN)
 
     @property

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -23,13 +23,6 @@ from django_q.tasks import async_task
 
 
 @receiver(post_save, sender=Gig)
-def notify_new_gig(sender, instance, created, **kwargs):
-    # This will have the side effect of creating plans for all members
-    async_task('gig.helpers.send_email_from_gig', instance,
-               'email/new_gig.md' if created else 'email/edited_gig.md')
-
-
-@receiver(post_save, sender=Gig)
 def set_calfeed_dirty(sender, instance, created, **kwargs):
     async_task('band.helpers.set_calfeeds_dirty', instance.band)
 

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -23,6 +23,12 @@ from django_q.tasks import async_task
 
 
 @receiver(post_save, sender=Gig)
+def create_member_plans(sender, instance, created, **kwargs):
+    """ if this is a new gig, make sure every member has a plan set """
+    if created:
+        x = instance.member_plans
+
+@receiver(post_save, sender=Gig)
 def set_calfeed_dirty(sender, instance, created, **kwargs):
     async_task('band.helpers.set_calfeeds_dirty', instance.band)
 

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -24,7 +24,7 @@ from django_q.tasks import async_task
 
 @receiver(post_save, sender=Gig)
 def create_member_plans(sender, instance, created, **kwargs):
-    """ if this is a new gig, make sure every member has a plan set """
+    """ makes sure every member has a plan set for a newly created gig """
     if created:
         x = instance.member_plans
 

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -375,31 +375,29 @@ class GigTest(TestCase):
         # up in the details block, which we're already checking to be localized
         self.assertIn('12:00', message.body)
 
-    # def test_gig_edit_definitely(self):
-    #     g, a, p = self.assoc_joe_and_create_gig()
-    #     p.status = Plan.StatusChoices.DEFINITELY
-    #     p.save()
-    #     mail.outbox = []
-    #     g.status = g.StatusOptions.CONFIRMED
-    #     g.save()
+    def test_gig_edit_definitely(self):
+        g, a, p = self.assoc_joe_and_create_gig()
+        p.status = Plan.StatusChoices.DEFINITELY
+        p.save()
+        mail.outbox = []
+        self.update_gig_form(g, status=g.StatusOptions.CONFIRMED)
 
-    #     message = mail.outbox[0]
-    #     self.assertIn(f'Your current status is "{Plan.StatusChoices.DEFINITELY.label}"', message.body)
-    #     self.assertNotIn('**can** make it', message.body)
-    #     self.assertIn("**can't** make it", message.body)
+        message = mail.outbox[0]
+        self.assertIn(f'Your current status is "{Plan.StatusChoices.DEFINITELY.label}"', message.body)
+        self.assertNotIn('**can** make it', message.body)
+        self.assertIn("**can't** make it", message.body)
 
-    # def test_gig_edit_cant(self):
-    #     g, a, p = self.assoc_joe_and_create_gig()
-    #     p.status = Plan.StatusChoices.CANT_DO_IT
-    #     p.save()
-    #     mail.outbox = []
-    #     g.status = g.StatusOptions.CONFIRMED
-    #     g.save()
+    def test_gig_edit_cant(self):
+        g, a, p = self.assoc_joe_and_create_gig()
+        p.status = Plan.StatusChoices.CANT_DO_IT
+        p.save()
+        mail.outbox = []
+        self.update_gig_form(g, status=g.StatusOptions.CONFIRMED)
 
-    #     message = mail.outbox[0]
-    #     self.assertIn(f'Your current status is "{Plan.StatusChoices.CANT_DO_IT.label}"', message.body)
-    #     self.assertIn('**can** make it', message.body)
-    #     self.assertNotIn("**can't** make it", message.body)
+        message = mail.outbox[0]
+        self.assertIn(f'Your current status is "{Plan.StatusChoices.CANT_DO_IT.label}"', message.body)
+        self.assertIn('**can** make it', message.body)
+        self.assertNotIn("**can't** make it", message.body)
 
     def test_answer_yes(self):
         _, _, p = self.assoc_joe_and_create_gig()

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -16,12 +16,14 @@
 """
 import copy
 from django.core import mail
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, RequestFactory
 from member.models import Member
 from band.models import Band, Section, Assoc
 from band.util import AssocStatusChoices
 from .models import Gig, Plan
 from .helpers import send_reminder_email, send_snooze_reminders
+from .forms import GigForm
+from .views import CreateView
 from go3 import settings
 from datetime import timedelta, datetime, time
 from django.urls import reverse
@@ -37,8 +39,8 @@ class GigTest(TestCase):
         self.band_admin = Member.objects.create_user(email='d@e.f')
         self.joeuser = Member.objects.create_user(email='g@h.i')
         self.janeuser = Member.objects.create_user(email='j@k.l')
-        self.band = Band.objects.create(name='test band', timezone='UTC')
-        Assoc.objects.create(member=self.band_admin, band=self.band, is_admin=True)
+        self.band = Band.objects.create(name='test band', timezone='UTC', anyone_can_create_gigs=True)
+        # Assoc.objects.create(member=self.band_admin, band=self.band, is_admin=True, status=AssocStatusChoices.CONFIRMED)
 
     def tearDown(self):
         """ make sure we get rid of anything we made """
@@ -52,6 +54,7 @@ class GigTest(TestCase):
             title="New Gig",
             band_id=self.band.id,
             date=thedate,
+<<<<<<< HEAD
             setdate=thedate + timedelta(minutes=30) if set_date == 'auto' else set_date,
             enddate=thedate + timedelta(hours=2) if end_date == 'auto' else end_date,
         )
@@ -59,11 +62,43 @@ class GigTest(TestCase):
     def assoc_joe_and_create_gig(self, **kw):
         a = Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
         g = self.create_gig(**kw)
+=======
+            setdate=thedate + timedelta(minutes=30),
+            enddate=thedate + timedelta(hours=2),
+            status=Gig.StatusOptions.UNKNOWN,
+        )
+
+    def create_gig_form(self, the_member):
+        thedate = timezone.datetime(2100,1,2, 12, tzinfo=pytz_timezone(self.band.timezone))
+        f = GigForm(data={'title':'New Gig',
+                          'date':thedate, 
+                          'setdate':thedate + timedelta(minutes=30),
+                          'enddate':thedate + timedelta(hours=2),
+                          'contact':the_member,
+                          'status':Gig.StatusOptions.UNKNOWN,
+                          'send_update': True
+                          })
+        r = RequestFactory().get(f'/gig/create/{self.band.id}')
+        r.user = the_member
+        v = CreateView()
+        v.setup(r, bk=self.band.id)
+        v.form_valid(f)
+        return v.object
+
+    def assoc_joe(self):
+        a = Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+        return a
+
+    def assoc_joe_and_create_gig(self):
+        a = self.assoc_joe()
+        g = self.create_gig_form(self.joeuser)
+>>>>>>> fixed gig tests now that just creating a test doesnt send emails - need to use the submit form
         p = g.member_plans.filter(assoc=a).get()
         return g, a, p
 
     def test_no_section(self):
         """ show that the band has a default section called 'No Section' """
+        self.assoc_joe()
         a = self.band.assocs.first()
         s = a.default_section
         self.assertTrue(s.is_default)
@@ -72,7 +107,7 @@ class GigTest(TestCase):
 
     def test_gig_plans(self):
         """ show that when a gig is created, every member has a plan """
-        g = self.create_gig()
+        g = self.create_gig(self.joeuser)
         self.assertEqual(g.plans.count(), self.band.assocs.count())
 
     def test_plan_section(self):
@@ -83,36 +118,50 @@ class GigTest(TestCase):
         self.assertEqual(self.band.sections.count(), 4)
 
         """ make the band's first assoc default to s1 section """
+        self.assoc_joe()
         a = self.band.assocs.first()
         a.default_section = s1
         a.save()
-        self.assertEqual(self.band_admin.assocs.first().default_section, s1)
-        self.assertEqual(self.band_admin.assocs.first().section, s1)
+        self.assertEqual(self.joeuser.assocs.first().default_section, s1)
+        self.assertEqual(self.joeuser.assocs.first().section, s1)
 
         """ now create a gig and find out what the member's plan says """
-        g = self.create_gig()
-        p = g.member_plans.first()
-        self.assertEqual(p.assoc.member, self.band_admin)
+        g = self.create_gig(self.band_admin)
+        p = g.member_plans.get(assoc__member=self.joeuser)
+        self.assertEqual(p.assoc.member, self.joeuser)
         self.assertEqual(p.plan_section, None) # we didn't set one so should be None
         self.assertEqual(p.section, s1) # should use the member's section
 
         """ change the member's default section and show that it changed for the gig """
         a.default_section=s2
         a.save()
-        p = g.plans.first()
+        p = g.plans.get(assoc__member=a.member)
         self.assertEqual(p.section, s2) # should use the member's section
 
         """ now show we override it if we set the plan section """
         p.plan_section = s3
         p.save()
-        p = g.plans.first()
+        p = g.plans.get(assoc__member=p.assoc.member)
         self.assertEqual(p.section, s3) # should use the override section
 
         """ now change the member's default but the plan should not change """
         a.default_section = s1
         a.save()
-        p = g.plans.first()
+        p = g.plans.get(assoc__member=a.member)
         self.assertEqual(p.section, s3) # should use the override section
+
+    def test_gig_create_permissions(self):
+        """ make sure that if I don't have permission to create a gig, I can't """
+        self.band.anyone_can_create_gigs = False
+        self.band.save()
+        with self.assertRaises(PermissionError):
+            self.create_gig_form(self.janeuser)
+
+    @override_settings(TEMPLATES=MISSING_TEMPLATES)
+    def test_new_gig_email(self):
+        self.create_gig_form(self.band_admin)
+        self.assertEqual(len(mail.outbox), 1)
+
 
     @override_settings(TEMPLATES=MISSING_TEMPLATES)
     def test_new_gig_email(self):

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -91,7 +91,7 @@ class GigTest(TestCase):
 
         """ now create a gig and find out what the member's plan says """
         g = self.create_gig()
-        p = g.plans.first()
+        p = g.member_plans.first()
         self.assertEqual(p.assoc.member, self.band_admin)
         self.assertEqual(p.plan_section, None) # we didn't set one so should be None
         self.assertEqual(p.section, s1) # should use the member's section
@@ -379,6 +379,244 @@ class GigTest(TestCase):
         self.assertIn(f'Your current status is "{Plan.StatusChoices.CANT_DO_IT.label}"', message.body)
         self.assertIn('**can** make it', message.body)
         self.assertNotIn("**can't** make it", message.body)
+    # @override_settings(TEMPLATES=MISSING_TEMPLATES)
+    # def test_new_gig_email(self):
+    #     g, a, p = self.assoc_joe_and_create_gig()
+    #     self.assertEqual(len(mail.outbox), 1)
+
+    #     message = mail.outbox[0]
+    #     self.assertIn(g.title, message.subject)
+    #     self.assertIn("01/02/2100 (Sat)", message.body)
+    #     self.assertIn('noon (Call Time), 12:30 p.m. (Set Time), 2 p.m. (End Time)', message.body)
+    #     self.assertIn('Unconfirmed', message.body)
+    #     self.assertIn(f'{p.id}/{Plan.StatusChoices.DEFINITELY}', message.body)
+    #     self.assertIn(f'{p.id}/{Plan.StatusChoices.CANT_DO_IT}', message.body)
+    #     self.assertIn(f'{p.id}/{Plan.StatusChoices.DONT_KNOW}', message.body)
+    #     self.assertNotIn('MISSING', message.subject)
+    #     self.assertNotIn('MISSING', message.body)
+
+    # def test_new_gig_all_confirmed(self):
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     self.create_gig()
+    #     self.assertEqual(len(mail.outbox), 2)
+
+    # def test_new_gig_obey_email_me(self):
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED, email_me=False)
+    #     self.create_gig()
+    #     self.assertEqual(len(mail.outbox), 1)
+
+    # def test_new_gig_contact(self):
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     Gig.objects.create(title="New Gig", band_id=self.band.id, date=timezone.now() + timedelta(days=1), contact=self.janeuser)
+
+    #     message = mail.outbox[0]
+    #     self.assertIn(self.janeuser.email, message.reply_to)
+    #     self.assertIn(self.janeuser.display_name, message.body)
+
+    # def test_new_gig_localization(self):
+    #     self.joeuser.preferences.language = 'de'
+    #     self.joeuser.save()
+    #     self.assoc_joe_and_create_gig()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('02.01.2100 (Sa)', message.body)
+    #     self.assertIn('12:00 (Beginn), 12:30 (Termin), 14:00 (Ende)', message.body)
+    #     self.assertIn('Nicht fixiert', message.body)
+
+    # def test_new_gig_time_localization(self):
+    #     self.joeuser.preferences.language='en-US'
+    #     self.joeuser.save()
+    #     self.band.timezone = 'America/New_York'
+    #     self.band.save()
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     g = self.create_gig()
+    #     self.assertEqual(len(mail.outbox), 1)
+    #     message = mail.outbox[0]
+    #     self.assertIn("01/02/2100 (Sat)", message.body)
+    #     self.assertIn('7 a.m. (Call Time), 7:30 a.m. (Set Time), 9 a.m. (End Time)', message.body)
+
+    # def test_gig_time_daylight_savings(self):
+    #     self.band.timezone = 'America/New_York'
+    #     self.band.save()
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+
+    #     # DST information only out to 2037?
+    #     Gig.objects.create(
+    #         title="January Gig",
+    #         band_id=self.band.id,
+    #         date=timezone.datetime(2037, 1, 2, 12, tzinfo=pytz_timezone('UTC'))
+    #     )
+    #     Gig.objects.create(
+    #         title="July Gig",
+    #         band_id=self.band.id,
+    #         date=timezone.datetime(2037, 7, 2, 12, tzinfo=pytz_timezone('UTC'))
+    #     )
+    #     self.assertIn('7 a.m. (Call Time)', mail.outbox[0].body)
+    #     self.assertIn('8 a.m. (Call Time)', mail.outbox[1].body)
+
+
+    # @override_settings(TEMPLATES=MISSING_TEMPLATES)
+    # def test_reminder_email(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     send_reminder_email(g)
+
+    #     self.assertEqual(len(mail.outbox), 1)
+    #     message = mail.outbox[0]
+    #     self.assertIn('Reminder', message.subject)
+    #     self.assertIn('reminder', message.body)
+    #     self.assertNotIn('MISSING', message.subject)
+    #     self.assertNotIn('MISSING', message.body)
+
+    # def test_no_reminder_to_decided(self):
+    #     g, a, p = self.assoc_joe_and_create_gig()
+    #     p.status = Plan.StatusChoices.DEFINITELY
+    #     p.save()
+    #     mail.outbox = []
+    #     send_reminder_email(g)
+
+    #     self.assertEqual(len(mail.outbox), 0)
+
+    # def test_snooze_reminder(self):
+    #     Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     g = self.create_gig()
+    #     g.member_plans.update(snooze_until=datetime.now(tz=timezone.get_current_timezone()))
+    #     mail.outbox = []
+    #     send_snooze_reminders()
+
+    #     self.assertEqual(len(mail.outbox), 2)
+    #     for message in mail.outbox:
+    #         self.assertIn('Reminder', message.subject)
+    #     self.assertEqual(g.member_plans.filter(snooze_until__isnull=False).count(), 0)
+
+    # def test_snooze_until_cutoff(self):
+    #     joeassoc = Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     janeassoc=Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     g = self.create_gig()
+    #     now = datetime.now(tz=timezone.get_current_timezone())
+    #     g.member_plans.filter(assoc=joeassoc).update(snooze_until=now)
+    #     g.member_plans.filter(assoc=janeassoc).update(snooze_until=now + timedelta(days=2))
+    #     mail.outbox = []
+    #     send_snooze_reminders()
+
+    #     self.assertEqual(len(mail.outbox), 1)
+
+    # def test_snooze_until_null(self):
+    #     a = Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+    #     g = self.create_gig()
+    #     now = datetime.now(tz=timezone.get_current_timezone())
+    #     g.member_plans.filter(assoc=a).update(snooze_until=now)
+    #     mail.outbox = []
+    #     send_snooze_reminders()
+
+    #     self.assertEqual(len(mail.outbox), 1)
+
+    # @override_settings(TEMPLATES=MISSING_TEMPLATES)
+    # def test_gig_edit_email(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     g.status = g.StatusOptions.CONFIRMED
+    #     g.save()
+
+    #     self.assertEqual(len(mail.outbox), 1)
+    #     message = mail.outbox[0]
+    #     self.assertIn('Edit', message.subject)
+    #     self.assertNotIn('Your current status', message.body)
+    #     self.assertIn('**can** make it', message.body)
+    #     self.assertIn("**can't** make it", message.body)
+    #     self.assertNotIn('MISSING', message.subject)
+    #     self.assertNotIn('MISSING', message.body)
+
+    # def test_gig_edit_status(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     g.status = g.StatusOptions.CONFIRMED
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('Status', message.subject)
+    #     self.assertIn('Confirmed!', message.body)
+    #     self.assertIn("(was Unconfirmed)", message.body)
+
+    # def test_gig_edit_call(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     g.date = g.date + timedelta(hours=2)
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('Call Time', message.subject)
+    #     self.assertIn('2 p.m.', message.body)
+    #     self.assertIn("(was noon)", message.body)
+
+    # def test_gig_edit_add_time(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     g.setdate = None
+    #     g.save()
+
+    #     mail.outbox = []
+    #     g.setdate = g.date + timedelta(hours=2)
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('Set Time', message.subject)
+    #     self.assertIn('2 p.m.', message.body)
+    #     self.assertIn("(was not set)", message.body)
+
+    # def test_gig_edit_contact(self):
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     g.contact = self.janeuser
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('Contact', message.subject)
+    #     self.assertIn(self.janeuser.display_name, message.body)
+    #     self.assertIn("(was ??)", message.body)
+
+    # def test_gig_edit_trans(self):
+    #     self.joeuser.preferences.language = 'de'
+    #     self.joeuser.save()
+    #     g, _, _ = self.assoc_joe_and_create_gig()
+    #     mail.outbox = []
+    #     g.date = g.date + timedelta(hours=2)
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn('Beginn', message.subject)
+    #     # We need to check the previous time, since the current time will show
+    #     # up in the details block, which we're already checking to be localized
+    #     self.assertIn('12:00', message.body)
+
+    # def test_gig_edit_definitely(self):
+    #     g, a, p = self.assoc_joe_and_create_gig()
+    #     p.status = Plan.StatusChoices.DEFINITELY
+    #     p.save()
+    #     mail.outbox = []
+    #     g.status = g.StatusOptions.CONFIRMED
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn(f'Your current status is "{Plan.StatusChoices.DEFINITELY.label}"', message.body)
+    #     self.assertNotIn('**can** make it', message.body)
+    #     self.assertIn("**can't** make it", message.body)
+
+    # def test_gig_edit_cant(self):
+    #     g, a, p = self.assoc_joe_and_create_gig()
+    #     p.status = Plan.StatusChoices.CANT_DO_IT
+    #     p.save()
+    #     mail.outbox = []
+    #     g.status = g.StatusOptions.CONFIRMED
+    #     g.save()
+
+    #     message = mail.outbox[0]
+    #     self.assertIn(f'Your current status is "{Plan.StatusChoices.CANT_DO_IT.label}"', message.body)
+    #     self.assertIn('**can** make it', message.body)
+    #     self.assertNotIn("**can't** make it", message.body)
 
     def test_answer_yes(self):
         _, _, p = self.assoc_joe_and_create_gig()

--- a/gig/views.py
+++ b/gig/views.py
@@ -58,6 +58,7 @@ class CreateView(generic.CreateView):
     def get_form_kwargs(self, *args, **kwargs):
         kwargs = super(CreateView, self).get_form_kwargs(*args, **kwargs)
         kwargs['band'] = Band.objects.get(id=self.kwargs['bk'])
+        kwargs['user'] = self.request.user
         return kwargs
 
     def form_valid(self, form):

--- a/gig/views.py
+++ b/gig/views.py
@@ -19,6 +19,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views import generic
 from django.urls import reverse
 from django.utils import timezone
+from django import forms
 from .models import Gig, Plan
 from .forms import GigForm
 from band.models import Band
@@ -26,17 +27,21 @@ from band.models import Band
 
 class DetailView(generic.DetailView):
     model = Gig
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['user_can_edit'] = self.request.user.is_superuser # todo or band members, admins etc.
-        context['user_can_create'] = self.request.user.is_superuser # todo or band members, admins etc.
+        # todo or band members, admins etc.
+        context['user_can_edit'] = self.request.user.is_superuser
+        # todo or band members, admins etc.
+        context['user_can_create'] = self.request.user.is_superuser
 
         return context
+
 
 class CreateView(generic.CreateView):
     model = Gig
     form_class = GigForm
-    
+
     def get_success_url(self):
         return reverse('gig-detail', kwargs={'pk': self.object.id})
 
@@ -46,6 +51,15 @@ class CreateView(generic.CreateView):
         context['the_band'] = Band.objects.get(id=self.kwargs['bk'])
         return context
 
+    # def get_initial(self):
+    #     initial = super(CreateView, self).get_initial()
+    #     initial['contact'] = Band.objects.get(id=self.kwargs['bk']).confirmed_members
+    #     return initial
+    def get_form_kwargs(self, *args, **kwargs):
+        kwargs = super(CreateView, self).get_form_kwargs(*args, **kwargs)
+        kwargs['band'] = Band.objects.get(id=self.kwargs['bk'])
+        return kwargs
+
     def form_valid(self, form):
 
         band = Band.objects.get(id=self.kwargs['bk'])
@@ -54,19 +68,24 @@ class CreateView(generic.CreateView):
         if self.request.user.is_superuser:
             has_permission = True
         else:
-            has_permission = band.anyone_can_create_gigs or band.is_admin(self.request.user)
+            has_permission = band.anyone_can_create_gigs or band.is_admin(
+                self.request.user)
 
         if has_permission is False:
-            raise(PermissionError, "Trying to create a gig without permission: {}".format(self.request.user.email))
+            raise(PermissionError, "Trying to create a gig without permission: {}".format(
+                self.request.user.email))
 
         form.instance.band = band
         return super(CreateView, self).form_valid(form)
 
+
 class UpdateView(generic.UpdateView):
     model = Gig
     form_class = GigForm
+
     def get_success_url(self):
         return reverse('gig-detail', kwargs={'pk': self.object.id})
+
 
 def answer(request, pk, val):
     plan = get_object_or_404(Plan, pk=pk)

--- a/gig/views.py
+++ b/gig/views.py
@@ -52,10 +52,6 @@ class CreateView(generic.CreateView):
         context['the_band'] = Band.objects.get(id=self.kwargs['bk'])
         return context
 
-    # def get_initial(self):
-    #     initial = super(CreateView, self).get_initial()
-    #     initial['contact'] = Band.objects.get(id=self.kwargs['bk']).confirmed_members
-    #     return initial
     def get_form_kwargs(self, *args, **kwargs):
         kwargs = super(CreateView, self).get_form_kwargs(*args, **kwargs)
         kwargs['band'] = Band.objects.get(id=self.kwargs['bk'])

--- a/gig/views.py
+++ b/gig/views.py
@@ -74,7 +74,7 @@ class CreateView(generic.CreateView):
                 self.request.user)
 
         if has_permission is False:
-            raise(PermissionError, "Trying to create a gig without permission: {}".format(
+            raise PermissionError("Trying to create a gig without permission: {}".format(
                 self.request.user.email))
 
         form.instance.band = band

--- a/lib/caldav.py
+++ b/lib/caldav.py
@@ -52,11 +52,9 @@ def make_calfeed(the_title, the_events, the_language, the_uid):
         """ description is the details, plus the setlist """
         x = ''
         if e.details:
-            # todo - need to do this replace?
-            x = '{0}'.format(e.details.replace('\r\n', '\\n'))
+            x = e.details
         if e.setlist:
-            x = '{0}\\n\\n{1}'.format(x, e.setlist.replace(
-                '\r\n', '\\n'))  # todo - need to do this replace?
+            x = f'{x}\\n\\n{e.setlist}'
         return x
 
     # set up language

--- a/lib/caldav.py
+++ b/lib/caldav.py
@@ -45,17 +45,15 @@ def make_calfeed(the_title, the_events, the_language, the_uid):
     """ construct an ical-compliant stream from a list of events """
 
     def _make_summary(event):
-        """ summary is the title, plus band name and status """
-        return '{0}:{1} {2}'.format(event.band.name, event.title, event.status)
+        """ makes the summary: the title, plus band name and status """
+        return f'{event.band.name}:{event.title} ({event.StatusOptions(event.status).label})'
 
     def _make_description(event):
         """ description is the details, plus the setlist """
-        x = ''
-        if e.details:
-            x = e.details
-        if e.setlist:
-            x = f'{x}\\n\\n{e.setlist}'
-        return x
+        deets = event.details if event.details else ''
+        setlist = event.setlist if event.setlist else ''
+        space = '\n\n' if deets and setlist else ''
+        return f'{deets}{space}{setlist}'
 
     # set up language
     cal = Calendar()

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -92,6 +92,32 @@ class CaldavTest(TestCase):
         self.assertTrue(cf.find(b'DTSTART;VALUE=DATE-TIME:20200229T143000Z')>0)
         self.assertTrue(cf.find(b'DTEND;VALUE=DATE-TIME:20200229T163000Z')>0)
 
+    def test_calfeed_description(self):
+        self.testgig.details = 'test desc'
+        self.testgig.save()
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
+        self.assertIn(b'DESCRIPTION:test desc\r\n',cf)
+
+    def test_calfeed_setlist(self):
+        self.testgig.setlist = 'test set'
+        self.testgig.save()
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
+        self.assertIn(b'DESCRIPTION:test set\r\n',cf)
+
+    def test_calfeed_details_setlist(self):
+        self.testgig.details = 'test details'
+        self.testgig.setlist = 'test set'
+        self.testgig.save()
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
+        self.assertIn(b'DESCRIPTION:test details\\n\\ntest set\r\n',cf)
+
+    def test_calfeed_summary(self):
+        self.testgig.details = 'test details'
+        self.testgig.setlist = 'test set'
+        self.testgig.save()
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
+        self.assertIn(b'SUMMARY:test band:New Gig (Unknown)\r\n',cf)
+    
 
 class CaldavFileTest(FSTestCase):
 

--- a/member/signals.py
+++ b/member/signals.py
@@ -25,7 +25,3 @@ def handle_user_preferences(sender, instance, created, **kwargs):
         MemberPreferences.objects.create(member=instance)
     else:
         instance.preferences.save()
-
-# @receiver(post_save, sender=Member)
-# def save_user_preferences(sender, instance, **kwargs):
-#     instance.preferences.save()

--- a/member/signals.py
+++ b/member/signals.py
@@ -23,7 +23,9 @@ from .models import Member, MemberPreferences
 def create_user_preferences(sender, instance, created, **kwargs):
     if created:
         MemberPreferences.objects.create(member=instance)
+    else:
+        instance.preferences.save()
 
-@receiver(post_save, sender=Member)
-def save_user_preferences(sender, instance, **kwargs):
-    instance.preferences.save()
+# @receiver(post_save, sender=Member)
+# def save_user_preferences(sender, instance, **kwargs):
+#     instance.preferences.save()

--- a/member/signals.py
+++ b/member/signals.py
@@ -20,7 +20,7 @@ from .models import Member, MemberPreferences
 
 # signals to make sure a set of preferences is created for every user
 @receiver(post_save, sender=Member)
-def create_user_preferences(sender, instance, created, **kwargs):
+def handle_user_preferences(sender, instance, created, **kwargs):
     if created:
         MemberPreferences.objects.create(member=instance)
     else:

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -133,15 +133,17 @@
                     {% render_field form.postgig class="form-control" %}
                 </div>
             </div>
+            <div class="form-group">
+                {{ form.details.errors }}
+                {{ form.details.label_tag }}
+                {% render_field form.details class="form-control" %}
+            </div>
+            <div class="form-group">
+                {{ form.setlist.errors }}
+                {{ form.setlist.label_tag }}
+                {% render_field form.setlist class="form-control" %}
+            </div>
 {% comment %}
-            <div class="form-group">
-                <label for="gigdetailsinput" class="col-form-label">{% trans "More Details" %}</label>
-                <textarea class="form-control" rows="10" id="gigdetailsinput" placeholder="{% trans "who? what? where? when? why?" %}" name="gig_details">{{gig.details}}</textarea>
-            </div>
-            <div class="form-group">
-                <label for="gigsetlistinput" class="col-form-label">{% trans "Setlist" %}</label>
-                <textarea class="form-control" rows="10" id="gigsetlistinput" placeholder="{% trans "setlist here" %}" name="gig_setlist">{{gig.setlist}}</textarea>
-            </div>
             {% if the_band.rss_feed %}
                 <div class="form-group">
                     <label for="gigrssdescriptioninput" class="col-form-label">{% trans "Description for RSS feed" %}</label>
@@ -161,30 +163,33 @@
                     </label>
                 </div>
             </div>
-            <div class="form-group">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="gig_invite_occasionals" name="gig_invite_occasionals" 
-                        {% if the_band.send_updates_by_default %}checked{% endif %}                        
-                        >
-                    <label class="form-check-label" for="gig_invite_occasionals">
-                        {% if is_new or is_dupe %}
-                            {% trans "Invite occasional members" %}
-                        {% else %}
-                            {% trans "Also send update to occasional members" %}  
-                        {% endif %}
-                    </label>  
-                </div>
+{% endcomment %}
+            <div class="form-check form-check-inline">
+                {{ form.invite_occasionals.errors }}
+                {% render_field form.invite_occasionals class="form-control" %}
+                <!-- {{ form.invite_occasionals.label_tag }} -->
+                <label class="form-check-label" for="gig_invite_occasionals">
+                    {% if is_new or is_dupe %}
+                        {% trans "Invite occasional members" %}
+                    {% else %}
+                        {% trans "Also send update to occasional members" %}  
+                    {% endif %}
+                </label>  
             </div>
-            <div class="form-group">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="gig_hide_from_calendar" name="gig_hide_from_calendar" 
+            <div class="form-check form-check-inline">
+                {{ form.hide_from_calendar.errors }}
+                {% render_field form.hide_from_calendar class="form-control" %}
+                {{ form.hide_from_calendar.label_tag }}
+            </div>
+                        <!-- <input class="form-check-input" type="checkbox" id="gig_hide_from_calendar" name="gig_hide_from_calendar" 
                         {% if gig.hide_from_calendar %}checked{% endif %}                        
                         >
                     <label class="form-check-label" for="gig_hide_from_calendar">
                         {% trans "Hide gig from calendars" %}
                     </label>
                 </div>
-            </div>
+            </div> -->
+{% comment %}
             {% if is_new %}
                 <div class="form-group">
                     <div class="form-check">

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -133,6 +133,7 @@
                     {% render_field form.postgig class="form-control" %}
                 </div>
             </div>
+{% comment %}
             <div class="form-group">
                 {{ form.details.errors }}
                 {{ form.details.label_tag }}

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -88,7 +88,7 @@
                         </div>
                     </div>
                 </div>
-            {% endif %}        
+            {% endif %}
             <div class="row">
                 <div class="form-group col-4">
                     <label for="gigcallinput" class="col-form-label">{% trans "Call Time" %}</label>
@@ -103,30 +103,37 @@
                     <input type="text" class="form-control" id="gigendinput" placeholder="" value="{{gig.endtime}}" name="gig_end">
                 </div>
             </div>
+{% endcomment %}            
             <div class="row">
                 <div class="form-group col-lg-4 col-md-4 col-12">
-                    <label for="gigaddressinput" class="col-form-label">{% trans "Address" %}</label>
-                    <input type="text" class="form-control" id="gigaddressinput" placeholder="{% trans "location_placeholder" %}" value="{{gig.address}}" name="gig_address">
+                    {{ form.address.errors }}
+                    {{ form.address.label_tag }}
+                    {% render_field form.address class="form-control" %}
                 </div>
                 <div class="form-group col-4">
-                    <label for="gigdressinput" class="col-form-label">{% trans "What To Wear" %}</label>
-                    <input type="text" class="form-control" id="gigdressinput" placeholder="{% trans "Pants Optional" %}" value="{{gig.dress}}" name="gig_dress">
+                    {{ form.dress.errors }}
+                    {{ form.dress.label_tag }}
+                    {% render_field form.dress class="form-control" %}
                 </div>
                 <div class="form-group col-4">
-                    <label for="gigpaidinput" class="col-form-label">{% trans "Pay Deal" %}</label>
-                    <input type="text" class="form-control" id="gigpaidinput" placeholder="{% trans "As If" %}" value="{{gig.paid}}" name="gig_paid">
+                    {{ form.paid.errors }}
+                    {{ form.paid.label_tag }}
+                    {% render_field form.paid class="form-control" %}
                 </div>
             </div>
             <div class="row">
                 <div class="form-group col-lg-4 col-md-4 col-12">
-                    <label for="gigleaderinput" class="col-form-label">{% trans "Leader" %}</label>
-                    <input type="text" class="form-control" id="gigleaderinput" placeholder="{% trans "leader_placeholder" %}" value="{{gig.leader}}" name="gig_leader">
+                    {{ form.leader.errors }}
+                    {{ form.leader.label_tag }}
+                    {% render_field form.leader class="form-control" %}
                 </div>
                 <div class="form-group col-lg-8 col-md-8 col-12">
-                    <label for="gigpostgiginput" class="col-form-label">{% trans "Post-gig Plans" %}</label>
-                    <input type="text" class="form-control" id="gigpostgiginput" placeholder="{% trans "postgig_placeholder" %}" value="{{gig.postgig}}" name="gig_postgig">
+                    {{ form.postgig.errors }}
+                    {{ form.postgig.label_tag }}
+                    {% render_field form.postgig class="form-control" %}
                 </div>
             </div>
+{% comment %}
             <div class="form-group">
                 <label for="gigdetailsinput" class="col-form-label">{% trans "More Details" %}</label>
                 <textarea class="form-control" rows="10" id="gigdetailsinput" placeholder="{% trans "who? what? where? when? why?" %}" name="gig_details">{{gig.details}}</textarea>

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -133,15 +133,19 @@
                     {% render_field form.postgig class="form-control" %}
                 </div>
             </div>
-            <div class="form-group">
+            <div class="row">
+                <div class="form-group col-12">
                 {{ form.details.errors }}
                 {{ form.details.label_tag }}
                 {% render_field form.details class="form-control" %}
+                </div>
             </div>
-            <div class="form-group">
-                {{ form.setlist.errors }}
-                {{ form.setlist.label_tag }}
-                {% render_field form.setlist class="form-control" %}
+            <div class="row">
+                <div class="form-group col-12">
+                    {{ form.setlist.errors }}
+                    {{ form.setlist.label_tag }}
+                    {% render_field form.setlist class="form-control" %}
+                </div>
             </div>
 {% comment %}
             {% if the_band.rss_feed %}
@@ -164,31 +168,35 @@
                 </div>
             </div>
 {% endcomment %}
-            <div class="form-check form-check-inline">
-                {{ form.invite_occasionals.errors }}
-                {% render_field form.invite_occasionals class="form-control" %}
-                <!-- {{ form.invite_occasionals.label_tag }} -->
-                <label class="form-check-label" for="gig_invite_occasionals">
-                    {% if is_new or is_dupe %}
-                        {% trans "Invite occasional members" %}
-                    {% else %}
-                        {% trans "Also send update to occasional members" %}  
-                    {% endif %}
-                </label>  
-            </div>
-            <div class="form-check form-check-inline">
-                {{ form.hide_from_calendar.errors }}
-                {% render_field form.hide_from_calendar class="form-control" %}
-                {{ form.hide_from_calendar.label_tag }}
-            </div>
-                        <!-- <input class="form-check-input" type="checkbox" id="gig_hide_from_calendar" name="gig_hide_from_calendar" 
-                        {% if gig.hide_from_calendar %}checked{% endif %}                        
-                        >
-                    <label class="form-check-label" for="gig_hide_from_calendar">
-                        {% trans "Hide gig from calendars" %}
-                    </label>
+            <div class="row">
+                <div class="col-12">
+                    {{ form.invite_occasionals.errors }}
+                    {{ form.invite_occasionals }}
+                    <!-- {{ form.invite_occasionals.label_tag }} -->
+                    <label for="gig_invite_occasionals">
+                        {% if is_new or is_dupe %}
+                            {% trans "Invite occasional members" %}
+                        {% else %}
+                            {% trans "Also send update to occasional members" %}  
+                        {% endif %}
+                    </label>  
                 </div>
-            </div> -->
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    {{ form.hide_from_calendar.errors }}
+                    {{ form.hide_from_calendar }}
+                    {{ form.hide_from_calendar.label_tag }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="form-group col-12">
+                    {{ form.send_update.errors }}
+                    {{ form.send_update }}
+                    {{ form.send_update.label_tag }}
+                </div>
+            </div>
+
 {% comment %}
             {% if is_new %}
                 <div class="form-group">

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -133,7 +133,6 @@
                     {% render_field form.postgig class="form-control" %}
                 </div>
             </div>
-{% comment %}
             <div class="form-group">
                 {{ form.details.errors }}
                 {{ form.details.label_tag }}


### PR DESCRIPTION
Added a bunch of fields to the gig edit form, including the "send update" options. Moved the code to send updates into the view handling for both creating and editing gigs, removing the signal that used to do it on gig save. Updated all tests to use form/view instead of just saving gig objects.