### PR TITLE
Set up automated pylint testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
+      id: pip
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
@@ -22,4 +23,5 @@ jobs:
         python manage.py collectstatic
         python manage.py test
     - name: Check with Pylint
+      if: ${{ always() && steps.pip.outcome == 'Success' }}
       run: modules=(*/__init__.py) && pylint -j0 ${modules[@]%/*}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         python manage.py collectstatic
         python manage.py test
+    - name: Check with Pylint
+      run: modules=(*/__init__.py) && pylint -j0 ${modules[@]%/*}

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,7 @@
+[MASTER]
+load-plugins=pylint_django
+
+[MESSAGES CONTROL]
+disable=all
+
+enable=F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode

--- a/band/helpers.py
+++ b/band/helpers.py
@@ -118,7 +118,7 @@ def join_assoc(request, bk, mk):
             'tying to create an assoc which is not owned by user {0}'.format(request.user.username))
 
     # OK, create the assoc
-    a = Assoc.objects.get_or_create(
+    Assoc.objects.get_or_create(
         band=b, member=m, status=AssocStatusChoices.PENDING)
 
     return HttpResponse()

--- a/band/signals.py
+++ b/band/signals.py
@@ -27,7 +27,7 @@ def set_condensed_name(sender, instance, **kwargs):
 @receiver(post_save, sender=Band)
 def set_default_section(sender, instance, created, **kwargs):
     if created:
-        s = Section.objects.create(name='No Section', band=instance, is_default=True)
+        _ = Section.objects.create(name='No Section', band=instance, is_default=True)
 
 @receiver(pre_save, sender=Assoc)
 def set_initial_default_section(sender, instance, **kwargs):

--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -116,8 +116,8 @@ def email_from_plan(plan, template):
         latest_record = gig.history.latest()
         changes = generate_changes(latest_record, latest_record.prev_record)
         member = plan.assoc.member
-        contact_name, contact_email = ((contact.display_name, contact.email)
-                                       if (contact := gig.contact) else ('??', None))
+        contact_name, contact_email = ((gig.contact.display_name, gig.contact.email)
+                                       if gig.contact else ('??', None))
         context = {
             'gig': gig,
             'changes': changes,

--- a/gig/signals.py
+++ b/gig/signals.py
@@ -26,7 +26,7 @@ from django_q.tasks import async_task
 def create_member_plans(sender, instance, created, **kwargs):
     """ makes sure every member has a plan set for a newly created gig """
     if created:
-        x = instance.member_plans
+        _ = instance.member_plans
 
 @receiver(post_save, sender=Gig)
 def set_calfeed_dirty(sender, instance, created, **kwargs):

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -173,7 +173,7 @@ class GigTest(TestCase):
 
     @flag_missing_vars
     def test_new_gig_email(self):
-        g, a, p = self.assoc_joe_and_create_gig()
+        g, _, p = self.assoc_joe_and_create_gig()
         self.assertEqual(len(mail.outbox), 1)
 
         message = mail.outbox[0]
@@ -282,7 +282,7 @@ class GigTest(TestCase):
         self.assertNotIn(MISSING, message.body)
 
     def test_no_reminder_to_decided(self):
-        g, a, p = self.assoc_joe_and_create_gig()
+        g, _, p = self.assoc_joe_and_create_gig()
         p.status = Plan.StatusChoices.DEFINITELY
         p.save()
         mail.outbox = []
@@ -400,7 +400,7 @@ class GigTest(TestCase):
         self.assertIn('12:00', message.body)
 
     def test_gig_edit_definitely(self):
-        g, a, p = self.assoc_joe_and_create_gig()
+        g, _, p = self.assoc_joe_and_create_gig()
         p.status = Plan.StatusChoices.DEFINITELY
         p.save()
         mail.outbox = []
@@ -412,7 +412,7 @@ class GigTest(TestCase):
         self.assertIn("**can't** make it", message.body)
 
     def test_gig_edit_cant(self):
-        g, a, p = self.assoc_joe_and_create_gig()
+        g, _, p = self.assoc_joe_and_create_gig()
         p.status = Plan.StatusChoices.CANT_DO_IT
         p.save()
         mail.outbox = []
@@ -463,7 +463,6 @@ class GigTest(TestCase):
         self.assertLessEqual((p.snooze_until - now).days, 7)
 
     def test_answer_snooze_too_short(self):
-        now = datetime.now(tz=timezone.get_current_timezone())
         g, _, p = self.assoc_joe_and_create_gig()
         g.date = timezone.now() + timedelta(days=1)
         g.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ MarkupSafe==1.1.1
 mccabe==0.6.1
 pyfakefs==4.0.2
 pylint==2.4.4
+pylint-django==2.0.14
 pytz==2019.3
 six==1.13.0
 sqlparse==0.3.0


### PR DESCRIPTION
This happened a bit accidentally.  I don't know if we want it or not, but we might as well take a look.

My editor (VSCode) automatically highlights pylint errors.  This is occasionally useful, but I was getting a lot of false positives because pylint doesn't understand the tricks the Django ORM is pulling.  But it turns out that there's a pylint-django package that fixes that.  I installed it, but you also have to tell pylint to use it.

I could have done that via an editor config, but I thought that anyone else using pylint would want this too, so I put it in a pylintrc file.  However, this triggered VSCode to switch from using it's list of rules to using all rules that pylint has.  And there are a lot of those!  So I copied VSCode's list of rules into the pylintrc file.  There may be some we don't care about, and there may be others that we do, but this seemed like a more reasonable starting place that "everything".

Of course, if we're keeping in the repo the list of pylint rules we care about, it's easy to test those in CI.  So I set that up too.

You'll notice that tests are not passing, because pylint complains about problems in our code.  The most common issue is unused variables, and most of these seem to be valid complaints.  Most of the rest seem to be false positives, so we'd have to disable the rule, either for the line or globally.  Don't know if we want to go down this route or not.

