### PR TITLE
Set user language on invite visit

### DIFF
--- a/member/tests.py
+++ b/member/tests.py
@@ -25,11 +25,12 @@ from .views import AssocsView, OtherBandsView
 from .helpers import prepare_calfeed, calfeed, update_all_calfeeds
 from lib.email import DEFAULT_SUBJECT, prepare_email
 from lib.template_test import MISSING, flag_missing_vars
+from django.conf import settings
 from django.contrib import auth
 from django.core import mail
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.urls import resolve, reverse
-from django.utils import timezone
+from django.utils import timezone, translation
 from datetime import timedelta
 import pytz
 import os
@@ -360,6 +361,34 @@ class InviteTest(TestCase):
         self.assertIn(template_name, (t.name for t in response.templates),
                       f'Response not rendered with {template_name}.')
 
+    def assertRenderLanguage(self, lang, render_cmd='django.shortcuts.render'):
+        test_case = self
+
+        class LanguageReport(Exception):
+            def __init__(self, lang):
+                self.lang = lang
+
+        def fake_render(*args, **kw):
+            raise LanguageReport(translation.get_language())
+
+        class RenderLanguageContextManager:
+
+            def __enter__(self):
+                self.patcher = patch(render_cmd, fake_render)
+                self.patcher.start()
+
+            def __exit__(self, exc_type, exc_value, tb):
+                self.patcher.stop()
+                if exc_type is None:
+                    test_case.fail("Render code was not called")
+                if isinstance(exc_value, LanguageReport):
+                    if exc_value.lang != lang:
+                        test_case.fail(f"Language when render was called was {exc_value.lang}; expected to be {lang}")
+                    return True
+                return False  # Other errors will be raised
+
+        return RenderLanguageContextManager()
+
     def test_invite_one(self):
         self.client.force_login(self.band_admin)
         response = self.client.post(reverse('member-invite'),
@@ -574,6 +603,27 @@ class InviteTest(TestCase):
         self.assertRedirects(response, reverse('member-detail', args=[self.joeuser.id]))
         self.assertEqual(Assoc.objects.filter(band=self.band, member=self.joeuser).count(), 1)
         self.assertEqual(Invite.objects.count(), 0)
+
+    def test_invite_sets_language(self):
+        invite = Invite.objects.create(email='jane@example.com', band=self.band, language='de')
+        self.client.get(reverse('member-invite-accept', args=[invite.id]))
+        self.assertEqual(self.client.cookies[settings.LANGUAGE_COOKIE_NAME].value, 'de')
+
+    def test_invite_uses_language(self):
+        invite = Invite.objects.create(email='jane@example.com', band=self.band, language='de')
+        with self.assertRenderLanguage('de', 'member.views.render'):
+            self.client.get(reverse('member-invite-accept', args=[invite.id]))
+
+    def test_invite_sets_language_on_redirect(self):
+        invite = Invite.objects.create(email='new@example.com', band=self.band, language='de')
+        self.client.get(reverse('member-invite-accept', args=[invite.id]))
+        self.assertEqual(self.client.cookies[settings.LANGUAGE_COOKIE_NAME].value, 'de')
+
+    def test_invite_does_not_override_language(self):
+        invite = Invite.objects.create(email='jane@example.com', band=self.band, language='de')
+        self.client.cookies[settings.LANGUAGE_COOKIE_NAME] = 'en-us'
+        self.client.get(reverse('member-invite-accept', args=[invite.id]))
+        self.assertEqual(self.client.cookies[settings.LANGUAGE_COOKIE_NAME].value, 'en-us')
 
     def test_create_member(self):
         invite = Invite.objects.create(email='new@example.com', band=self.band)

--- a/member/views.py
+++ b/member/views.py
@@ -177,6 +177,7 @@ def accept_invite(request, pk):
     invite = get_object_or_404(Invite, pk=pk)
 
     if not (request.user.is_authenticated or settings.LANGUAGE_COOKIE_NAME in request.COOKIES):
+        # We need the language active before we try to render anything.
         translation.activate(invite.language)
         def set_language(response):
             response.set_cookie(settings.LANGUAGE_COOKIE_NAME, invite.language)

--- a/member/views.py
+++ b/member/views.py
@@ -175,6 +175,16 @@ def invite(request):
 
 def accept_invite(request, pk):
     invite = get_object_or_404(Invite, pk=pk)
+
+    if not (request.user.is_authenticated or settings.LANGUAGE_COOKIE_NAME in request.COOKIES):
+        translation.activate(invite.language)
+        def set_language(response):
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, invite.language)
+            return response
+    else:
+        def set_language(response):
+            return response
+
     if request.user.is_authenticated and request.GET.get('claim') == 'true':
         member = request.user
     else:
@@ -189,16 +199,16 @@ def accept_invite(request, pk):
         invite.delete()
         if request.user.is_authenticated:
             return redirect('member-detail', pk=member.id)
-        translation.activate(invite.language)
-        return render(request, 'member/accepted.html',
-                        {'band_name': invite.band.name if invite.band else None,
-                        'member_id': member.id})
+        return set_language(
+                   render(request, 'member/accepted.html',
+                          {'band_name': invite.band.name if invite.band else None,
+                          'member_id': member.id}))
 
     if request.user.is_authenticated:  # The user is signed in, but as a different user
         return render(request, 'member/claim_invite.html', {'invite': invite, 'member': member})
 
     # New user
-    return redirect('member-create', pk=invite.id)
+    return set_language(redirect('member-create', pk=invite.id))
 
 
 class MemberCreateView(CreateView):


### PR DESCRIPTION
Before, we were using the invite language to set the language of one render.  Now, we use it to set the user's language, if it isn't already set.  The first commit message includes more details about the logic.

Also added some better testing around language settings and use.