### PR TITLE
Separate language test into separate base class

### DIFF
--- a/lib/template_test.py
+++ b/lib/template_test.py
@@ -1,6 +1,8 @@
 import copy
+from unittest.mock import patch
 
-from django.test import override_settings
+from django.test import override_settings, TestCase
+from django.utils import translation
 from go3 import settings
 
 MISSING = 'MISSING'
@@ -8,3 +10,37 @@ MISSING_TEMPLATES = copy.deepcopy(settings.TEMPLATES)
 MISSING_TEMPLATES[0]['OPTIONS']['string_if_invalid'] = f'{MISSING}: %s'
 
 flag_missing_vars = override_settings(TEMPLATES=MISSING_TEMPLATES)
+
+
+class TemplateTestCase(TestCase):
+
+    def assertOK(self, response):
+        self.assertEqual(response.status_code, 200)
+
+    def assertRenderLanguage(self, lang, render_cmd='django.shortcuts.render'):
+        test_case = self
+
+        class LanguageReport(Exception):
+            def __init__(self, lang):
+                self.lang = lang
+
+        def fake_render(*args, **kw):
+            raise LanguageReport(translation.get_language())
+
+        class RenderLanguageContextManager:
+
+            def __enter__(self):
+                self.patcher = patch(render_cmd, fake_render)
+                self.patcher.start()
+
+            def __exit__(self, exc_type, exc_value, tb):
+                self.patcher.stop()
+                if exc_type is None:
+                    test_case.fail("Render code was not called")
+                if isinstance(exc_value, LanguageReport):
+                    if exc_value.lang != lang:
+                        test_case.fail(f"Language when render was called was {exc_value.lang}; expected to be {lang}")
+                    return True
+                return False  # Other errors will be raised
+
+        return RenderLanguageContextManager()

--- a/member/tests.py
+++ b/member/tests.py
@@ -357,10 +357,6 @@ class InviteTest(TestCase):
     def assertOK(self, response):
         self.assertEqual(response.status_code, 200)
 
-    def assertRenderedWith(self, response, template_name):
-        self.assertIn(template_name, (t.name for t in response.templates),
-                      f'Response not rendered with {template_name}.')
-
     def assertRenderLanguage(self, lang, render_cmd='django.shortcuts.render'):
         test_case = self
 
@@ -580,7 +576,7 @@ class InviteTest(TestCase):
         invite = Invite.objects.create(email='jane@example.com', band=self.band)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/accepted.html')
+        self.assertTemplateUsed(response, 'member/accepted.html')
         self.assertEqual(Assoc.objects.filter(band=self.band, member=self.janeuser).count(), 1)
         self.assertEqual(Invite.objects.count(), 0)
 
@@ -588,7 +584,7 @@ class InviteTest(TestCase):
         invite = Invite.objects.create(email='jane@example.com', band=None)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/accepted.html')
+        self.assertTemplateUsed(response, 'member/accepted.html')
         self.assertEqual(Assoc.objects.filter(member=self.janeuser).count(), 0)
         self.assertEqual(Invite.objects.count(), 0)
 
@@ -598,7 +594,7 @@ class InviteTest(TestCase):
         self.client.force_login(self.joeuser)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/claim_invite.html')
+        self.assertTemplateUsed(response, 'member/claim_invite.html')
         self.assertIn(b'accept the invite as', response.content)
         self.assertEqual(Invite.objects.count(), 1)  # Didn't delete the invite
         self.assertEqual(Assoc.objects.count(), n_assoc)  # Didn't create an Assoc
@@ -611,7 +607,7 @@ class InviteTest(TestCase):
         self.client.force_login(self.joeuser)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/claim_invite.html')
+        self.assertTemplateUsed(response, 'member/claim_invite.html')
         self.assertIn(b'accept the invite as', response.content)
         self.assertEqual(Invite.objects.count(), 1)  # Didn't delete the invite
         self.assertEqual(Assoc.objects.count(), n_assoc)  # Didn't create an Assoc
@@ -622,7 +618,7 @@ class InviteTest(TestCase):
         self.client.force_login(self.joeuser)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/claim_invite.html')
+        self.assertTemplateUsed(response, 'member/claim_invite.html')
         self.assertIn(b'create an account for', response.content)
         self.assertEqual(Invite.objects.count(), 1)  # Didn't delete the invite
         self.assertEqual(Assoc.objects.count(), n_assoc)  # Didn't create an Assoc
@@ -633,7 +629,7 @@ class InviteTest(TestCase):
         self.client.force_login(self.joeuser)
         response = self.client.get(reverse('member-invite-accept', args=[invite.id]))
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/claim_invite.html')
+        self.assertTemplateUsed(response, 'member/claim_invite.html')
         self.assertIn(b'create an account for', response.content)
         self.assertEqual(Invite.objects.count(), 1)  # Didn't delete the invite
         self.assertEqual(Assoc.objects.count(), n_assoc)  # Didn't create an Assoc
@@ -730,7 +726,7 @@ class InviteTest(TestCase):
                                      'password2': self.password},
                                     follow=True)
         self.assertOK(response)
-        self.assertRenderedWith(response, 'member/member_detail.html')
+        self.assertTemplateUsed(response, 'member/member_detail.html')
 
     def test_create_duplicate_member(self):
         invite = Invite.objects.create(email='jane@example.com', band=self.band)


### PR DESCRIPTION
I'd been unhappy about the inability to test the language used for rendering.  I liked the solution I figured out in #52, so this moves it into a general base test class we can use.

I had initially thought that this would allow us to replace some of the other language tests that are checking the actual test.  But when I looked into them, they're less concerned about the language being set than they are about making sure string operations are lazy enough that they don't happen before the language is set.  This test wouldn't catch those, so I left them as-is.  Still, this seems worth separating out.

In the process of figuring out the details, I learned there was already an assert method to test template usage, so I removed the custom one we were using.