### PR TITLE
Add band navigator page

### DIFF
--- a/band/urls.py
+++ b/band/urls.py
@@ -21,7 +21,7 @@ from . import views
 from . import helpers
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('', views.BandList.as_view(), name='band-nav'),
     path('<int:pk>/', views.DetailView.as_view(), name='band-detail'),
     path('<int:pk>/update', views.UpdateView.as_view(), name='band-update'),
     path('<int:pk>/members/', views.AllMembersView.as_view(), name='all-members'),

--- a/band/views.py
+++ b/band/views.py
@@ -9,9 +9,10 @@ from .forms import BandForm
 from .util import AssocStatusChoices, BandStatusChoices
 from member.models import Invite
 
-class BandList(generic.ListView):
+class BandList(LoginRequiredMixin, generic.ListView):
     queryset = Band.objects.filter(status=BandStatusChoices.ACTIVE).order_by('name')
     context_object_name = 'bands'
+
 
 class DetailView(generic.DetailView):
     model = Band

--- a/band/views.py
+++ b/band/views.py
@@ -6,11 +6,12 @@ from django.urls import reverse
 from django.contrib.auth.mixins import LoginRequiredMixin
 from .models import Band, Assoc, Section
 from .forms import BandForm
-from .util import AssocStatusChoices
+from .util import AssocStatusChoices, BandStatusChoices
 from member.models import Invite
 
-def index(request):
-    return HttpResponse("Hello, world. You're at the band index.")
+class BandList(generic.ListView):
+    queryset = Band.objects.filter(status=BandStatusChoices.ACTIVE).order_by('name')
+    context_object_name = 'bands'
 
 class DetailView(generic.DetailView):
     model = Band

--- a/templates/band/band_list.html
+++ b/templates/band/band_list.html
@@ -1,0 +1,21 @@
+{% extends 'base/go3base.html' %}
+{% load i18n %}
+{% load widget_tweaks %}
+
+{% block title %}{% trans "Band Navigator" %}{% endblock title %}
+
+{% block content %}
+<div class="row">
+    <div class="mx-auto mb-4 col-lg-8 col-md-10 col-sm-12">
+        <div class="page-header">
+            {% trans "Band Navigator" %}
+        </div>
+    </div>
+    {% for b in bands %}
+        <div class="mx-auto col-lg-8 col-md-10 col-sm-12">
+            <a href="{% url 'band-detail' pk=b.id %}">{{ b.name }}</a>
+            {% if b.hometown %}({{ b.hometown }}){% endif %}
+        </div>
+    {% endfor %}
+</div>
+{% endblock content %}

--- a/templates/base/navbar.html
+++ b/templates/base/navbar.html
@@ -33,14 +33,14 @@
               {% endwith %}
             {% endfor %}
             <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="/band_nav.html">{% trans "Band Navigator" %}</a>
+              <a class="dropdown-item" href="{% url 'band-nav' %}">{% trans "Band Navigator" %}</a>
           {% else %}
 	          <a class="dropdown-item" href="#">{% trans "No bands yet!" %}</a>
           {% endif %}
         {% endwith %}
         </div>
       </li>
-          
+
       {% with the_assocs=request.user.add_gig_assocs.all %}
         {% if the_assocs|length == 1 %}
           <li class="nav-item {% if newgig_is_active %} active{% endif %} mr-2">
@@ -61,7 +61,7 @@
           </li>
         {% endif %}
       {% endwith %}
-              
+
       {% if request.user.is_superuser %}
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarAdminMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
In the current implementation, it displays only "active" bands.  Should "dormant" bands also be listed?

In v2, bands had a 'show_in_nav' property to control whether they appeared.  Should that still exist, or has it been superseded by the 'status' property?