### PR TITLE
Improve member admin section of band details page

### DIFF
--- a/band/urls.py
+++ b/band/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('<int:pk>/update', views.UpdateView.as_view(), name='band-update'),
     path('<int:pk>/members/', views.AllMembersView.as_view(), name='all-members'),
     path('<int:pk>/section/<int:sk>', views.SectionMembersView.as_view(), name='section-members'),
+    path('<int:pk>/member_spreadsheet', views.member_spreadsheet, name='member-spreadsheet'),
 
     path('assoc/<int:ak>/tfparam/<str:param>/<str:truefalse>', helpers.set_assoc_tfparam, name='assoc-tfparam'),
     path('assoc/<int:ak>/color/<int:colorindex>', helpers.set_assoc_color, name='assoc-color'),

--- a/band/urls.py
+++ b/band/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('<int:pk>/members/', views.AllMembersView.as_view(), name='all-members'),
     path('<int:pk>/section/<int:sk>', views.SectionMembersView.as_view(), name='section-members'),
     path('<int:pk>/member_spreadsheet', views.member_spreadsheet, name='member-spreadsheet'),
+    path('<int:pk>/member_emails', views.member_emails, name='member-emails'),
 
     path('assoc/<int:ak>/tfparam/<str:param>/<str:truefalse>', helpers.set_assoc_tfparam, name='assoc-tfparam'),
     path('assoc/<int:ak>/color/<int:colorindex>', helpers.set_assoc_color, name='assoc-color'),

--- a/band/views.py
+++ b/band/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from .models import Band, Assoc, Section
 from .forms import BandForm
 from .util import AssocStatusChoices
@@ -104,3 +104,13 @@ def member_spreadsheet(request, pk):
         writer.writerow([member.username, member.nickname, member.email, member.phone, assoc.section.name])
 
     return response
+
+
+@login_required
+def member_emails(request, pk):
+    band = get_object_or_404(Band, pk=pk)
+    if not (band.is_admin(request.user) or request.user.is_superuser):
+        raise PermissionDenied
+
+    emails = ', '.join(a.member.email for a in band.confirmed_assocs)
+    return render(request, 'band/member_emails.html', context={'band': band, 'emails': emails})

--- a/member/tests.py
+++ b/member/tests.py
@@ -19,7 +19,7 @@ from unittest.mock import patch, mock_open
 
 from django.test import TestCase, RequestFactory
 from .models import Member, MemberPreferences, Invite
-from band.models import Band, Assoc
+from band.models import Band, Assoc, AssocStatusChoices
 from gig.models import Gig, Plan
 from .views import AssocsView, OtherBandsView
 from .helpers import prepare_calfeed, calfeed, update_all_calfeeds
@@ -343,8 +343,8 @@ class InviteTest(TestCase):
         self.joeuser = Member.objects.create_user(email='joe@example.com')
         self.janeuser = Member.objects.create_user(email='jane@example.com')
         self.band = Band.objects.create(name='test band')
-        Assoc.objects.create(member=self.band_admin, band=self.band, is_admin=True)
-        Assoc.objects.create(member=self.joeuser, band=self.band)
+        Assoc.objects.create(member=self.band_admin, band=self.band, status=AssocStatusChoices.CONFIRMED, is_admin=True)
+        Assoc.objects.create(member=self.joeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
         self.password = 'sb8bBb5cGmE2uNn'  # Random value, but validates
 
     def tearDown(self):

--- a/member/views.py
+++ b/member/views.py
@@ -165,10 +165,7 @@ class InviteView(LoginRequiredMixin, FormView):
         band = get_object_or_404(Band, pk=self.kwargs['bk'])
         emails = form.cleaned_data['emails'].replace(',', ' ').split()
 
-        user_is_band_admin = Assoc.objects.filter(
-            member=self.request.user, band=band, is_admin=True).count() == 1
-
-        if not (user_is_band_admin or self.request.user.is_superuser):
+        if not (band.is_admin(self.request.user) or self.request.user.is_superuser):
             raise PermissionDenied
 
         invited, in_band, invalid = [], [], []
@@ -285,10 +282,8 @@ class MemberCreateView(CreateView):
 @login_required
 def delete_invite(request, pk):
     invite = get_object_or_404(Invite, pk=pk)
-    user_is_band_admin = Assoc.objects.filter(
-        member=request.user, band=invite.band, is_admin=True).count() == 1
     user_is_invitee = (request.user.email == invite.email)
-    if not (user_is_band_admin or user_is_invitee or request.user.is_superuser):
+    if not (invite.band.is_admin(request.user) or user_is_invitee or request.user.is_superuser):
         raise PermissionDenied
 
     invite.delete()

--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -183,16 +183,19 @@ a {
     border-color: #007bff;
 }
 
-.accordion .card-header:after {
-    font-family: 'Font Awesome 5 Pro';  
+.card-header[data-toggle="collapse"] {
+    cursor: pointer;
+}
+.card-header[data-toggle="collapse"]:after {
+    font-family: 'Font Awesome 5 Pro';
     font-weight: 900;
     content: "\f068";
     padding-right: .5rem;
-    float: left; 
+    float: left;
 }
-.accordion .card-header.collapsed:after {
+.card-header[data-toggle="collapse"].collapsed:after {
     /* symbol for "collapsed" panels */
-    content: "\f067"; 
+    content: "\f067";
 }
 
 

--- a/templates/band/band_detail.html
+++ b/templates/band/band_detail.html
@@ -298,7 +298,7 @@
                         <div class="row">
                             <div class="col-12">
                                 <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
-                                <a class="btn btn-primary btn-sm" href="member_spreadsheet?bk={{band.id}}">{% trans "Download Member List" %}</a>
+                                <a class="btn btn-primary btn-sm" href="{% url 'member-spreadsheet' pk=band.id %}">{% trans "Download Member List" %}</a>
                                 <a class="btn btn-primary btn-sm" href="member_emails?bk={{band.id}}">{% trans "Get Member Emails" %}</a>
 
                             </div>

--- a/templates/band/band_detail.html
+++ b/templates/band/band_detail.html
@@ -299,7 +299,7 @@
                             <div class="col-12">
                                 <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
                                 <a class="btn btn-primary btn-sm" href="{% url 'member-spreadsheet' pk=band.id %}">{% trans "Download Member List" %}</a>
-                                <a class="btn btn-primary btn-sm" href="member_emails?bk={{band.id}}">{% trans "Get Member Emails" %}</a>
+                                <a class="btn btn-primary btn-sm" href="{% url 'member-emails' pk=band.id %}">{% trans "Get Member Emails" %}</a>
 
                             </div>
                             <hr>

--- a/templates/band/band_detail.html
+++ b/templates/band/band_detail.html
@@ -288,29 +288,25 @@
             </div> <!-- panel -->
 
             {% if the_user_is_band_admin or request.user.is_superuser %}
-                <div class="accordion mt-4" id="accordion">
-                    <div class="card">
-                        <div class="card-header collapsed" data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                            <a class="card-title titlerow">
-                                {% trans "Member Admin" %}
-                            </a>
-                        </div>
-                        <div id="collapseOne" class="collapse" role="tabpanel" aria-labelledby="headingOne" data-parent="#accordion">
-                            <div class="card-body">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
-                                        <a class="btn btn-primary btn-sm" href="member_spreadsheet?bk={{band.id}}">{% trans "Download Member List" %}</a>
-                                        <a class="btn btn-primary btn-sm" href="member_emails?bk={{band.id}}">{% trans "Get Member Emails" %}</a>
+                <div class="mt-4 card">
+                    <div class="card-header collapsed" data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                        <a class="card-title titlerow">
+                            {% trans "Member Admin" %}
+                        </a>
+                    </div>
+                    <div id="collapseOne" class="collapse card-body" role="tabpanel" aria-labelledby="headingOne">
+                        <div class="row">
+                            <div class="col-12">
+                                <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
+                                <a class="btn btn-primary btn-sm" href="member_spreadsheet?bk={{band.id}}">{% trans "Download Member List" %}</a>
+                                <a class="btn btn-primary btn-sm" href="member_emails?bk={{band.id}}">{% trans "Get Member Emails" %}</a>
 
-                                    </div>
-                                    <hr>
-                                </div>
-                                <div class="row">
-                                    <div class="col-12" id="memberlist">
-                                        <i class="fas fa-spinner fa-pulse fa-lg"></i>
-                                    </div>
-                                </div>
+                            </div>
+                            <hr>
+                        </div>
+                        <div class="row">
+                            <div class="col-12" id="memberlist">
+                                <i class="fas fa-spinner fa-pulse fa-lg"></i>
                             </div>
                         </div>
                     </div>

--- a/templates/band/member_emails.html
+++ b/templates/band/member_emails.html
@@ -1,0 +1,15 @@
+{% extends 'base/go3base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Band Emails" %}{% endblock title %}
+
+{% block content %}
+<div class="row">
+    <div class="mx-auto col-lg-8 col-md-10 col-12">
+        <div class="page-header">
+            {{ band.name }} {% trans "email addresses" %}
+        </div>
+        {{ emails }}
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
This involves:
1. Fixing up the display of the collapsing card.
2. Adding the member spreadsheet endpoint.
3. Adding the member emails endpoint.

In the process, I realized that Band.is_admin exists, when I had reimplemented it in the invitation system.  So I swapped that out, which required some updates to tests.