### PR TITLE
Fix permissions for setting Assoc properties

### DIFF
--- a/templates/band/band_all_members.html
+++ b/templates/band/band_all_members.html
@@ -58,7 +58,7 @@
             </div>
         {% endif %}
 
-        {% if the_assoc.member.id != request.user.key %}
+        {% if the_assoc.member != request.user %}
             <div class="col-md-2">
                 <div class="form-check">
                     <input class="form-check-input"
@@ -81,6 +81,26 @@
                    hx-post="{% url 'assoc-delete' ak=the_assoc.id %}">
                     {% trans "remove from band" %}
                 </a>
+            </div>
+        {% else %}
+            <div class="col-md-2">
+                <div class="form-check">
+                    <input class="form-check-input"
+                           type="checkbox"
+                           id='aak-{{ the_assoc.id }}'
+                           name="is_admin"
+                           disabled
+                    {% if the_assoc.is_admin %}
+                           checked
+                    {% endif %}
+                    >
+                    <label class="form-check-label" for='aak-{{ the_assoc.id }}'>{% trans "admin" %}</label>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <button type="button" class="btn btn-secondary btn-sm" disabled>
+                    {% trans "remove from band" %}
+                </button>
             </div>
         {% endif %}
     </div>


### PR DESCRIPTION
As noted in #63, there is a problem in permissions around the tfparams -- any user could set themselves to be an admin.  As I was looking into it, I realized there were additional problems: band admins couldn't set properties of Assocs for people in their band.  Since the logic around this is repeated for a variety of endpoints, I pulled it out into another decorator.  In the process, I switched a lot of exceptions to 403 responses.

The member admin template was designed to not show admins the options to undo their own admin-ness or leave the band, but that was broken.  I've fixed it, and added disabled elements in this case, to make it more obvious that we intend not to give them these options.

I've built it on top of #63.  We can merge this into there before it lands, or retarget this to master after it lands.