### PR TITLE
integrate django admin site

### DIFF
--- a/templates/base/navbar.html
+++ b/templates/base/navbar.html
@@ -68,10 +68,7 @@
             {% trans "Admin" %}
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarAdminMenuLink">
-            <a class="dropdown-item" href="/member_admin">{% trans "Member Admin" %}</a>
-            <a class="dropdown-item" href="/band_admin">{% trans "Band Admin" %}</a>
-            <a class="dropdown-item" href="/motd_admin">{% trans "MOTD Admin" %}</a>
-            <a class="dropdown-item" href="/crypto_admin">{% trans "CryptoKey Admin" %}</a>
+            <a class="dropdown-item" href="/admin">{% trans "Admin Pages" %}</a>
             <a class="dropdown-item" href="/stats">{% trans "Stats Page" %}</a>
             <a class="dropdown-item" href="/_ah/stats" target="_new">{% trans "AppStats" %}</a>
           </div>


### PR DESCRIPTION
Instead of custom admin pages for members and bands, just link to the django admin site. Not really necessary but convenient.