### PR TITLE
Deleting members

### DIFF
--- a/band/models.py
+++ b/band/models.py
@@ -122,7 +122,7 @@ class MemberAssocManager(models.Manager):
 
     def confirmed_assocs(self, member):
         """ returns the asocs for bands we're confirmed for """
-        return super().get_queryset().filter(member=member, status=AssocStatusChoices.CONFIRMED)
+        return super().get_queryset().filter(member=member, member__status=MemberStatusChoices.ACTIVE, status=AssocStatusChoices.CONFIRMED)
 
     def add_gig_assocs(self, member):
         """ return the assocs for bands the member can create gigs for """

--- a/member/admin.py
+++ b/member/admin.py
@@ -37,7 +37,7 @@ class MemberAdmin(BaseUserAdmin):
     # that reference specific fields on auth.User.
 
     list_display = ('email', 'username', 'nickname')
-    list_filter = ()
+    list_filter = ('status',)
     fieldsets = (
         (None, {'fields': ('email', 'password')}),
         ('Personal info', {'fields': ('username','nickname','phone')}),

--- a/member/admin.py
+++ b/member/admin.py
@@ -47,7 +47,7 @@ class MemberAdmin(BaseUserAdmin):
         ('Important dates', {'fields': ('last_login', 'date_joined')}),
         ('Other stuff', {'classes': ('collapse',),
                          'fields': ('statement', 'motd_dirty', 'seen_welcome', 
-                                    'images', 'cal_feed_dirty',
+                                    'images', 'cal_feed_dirty','status'
                                     )}),
     )
 

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -18,6 +18,8 @@
 from django.http import HttpResponse, HttpResponseForbidden
 from django.utils import timezone
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth import logout
+from django.shortcuts import get_object_or_404, redirect
 from datetime import timedelta
 
 from gig.models import Gig, Plan
@@ -50,9 +52,14 @@ def motd_seen(request, pk):
     return HttpResponse()
 
 @login_required
-@superuser_required
 def delete_member(request, pk):
-    return HttpResponse()
+    member = get_object_or_404(Member, pk=pk)
+    if request.user != member and request.user.is_superuser is False:
+        return HttpResponseForbidden()
+    member.delete()
+    if request.user.is_superuser is False:
+        logout(request)
+    return redirect('home')
 
 def send_invite(invite):
     context = {

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -15,7 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 from django.utils import timezone
 from django.contrib.auth.decorators import login_required
 from datetime import timedelta

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -29,6 +29,14 @@ from lib.caldav import make_calfeed, save_calfeed, get_calfeed
 from django.core.exceptions import ValidationError
 from django.conf import settings
 
+def superuser_required(func):
+    def decorated(request, pk, *args, **kw):
+        if not request.user.is_superuser:
+            return HttpResponseForbidden()
+
+        return func(request, pk, *args, **kw)
+    return decorated
+
 
 @login_required
 def motd_seen(request, pk):
@@ -41,6 +49,10 @@ def motd_seen(request, pk):
 
     return HttpResponse()
 
+@login_required
+@superuser_required
+def delete_member(request, pk):
+    return HttpResponse()
 
 def send_invite(invite):
     context = {

--- a/member/models.py
+++ b/member/models.py
@@ -147,6 +147,7 @@ class Member(AbstractUser):
         """ when we get deleted, remove plans for future gigs and set us to deleted """
         Plan.member_plans.future_plans(self).delete()
         self.status = MemberStatusChoices.DELETED
+        self.email = "user_{0}@gig-o-matic.com".format(self.id)
         self.save()
 
     objects = MemberManager()

--- a/member/models.py
+++ b/member/models.py
@@ -65,6 +65,9 @@ class MemberManager(BaseUserManager):
 
         return self._create_user(email, password, **extra_fields)
 
+    def active(self):
+        return self.all().filter(status=MemberStatusChoices.ACTIVE)
+
 
 # a 1-1 link to user model
 # https://simpleisbetterthancomplex.com/tutorial/2016/07/22/how-to-extend-django-user-model.html#onetoone
@@ -140,6 +143,9 @@ class Member(AbstractUser):
         return EmailRecipient(name=self.username, email=self.email,
                               language=self.preferences.language) # pylint: disable=no-member
 
+    def delete(self, *args, **kwargs):
+        self.status = MemberStatusChoices.DELETED
+
     objects = MemberManager()
 
     USERNAME_FIELD = 'email'
@@ -153,7 +159,7 @@ class Member(AbstractUser):
         verbose_name_plural = _('members')
 
     def __str__(self):
-        return '{0}'.format(self.display_name)
+        return '{0}{1}'.format(self.display_name, ' (deleted)' if self.status==MemberStatusChoices.DELETED else '')
 
 
 class MemberPreferences(models.Model):

--- a/member/models.py
+++ b/member/models.py
@@ -144,7 +144,10 @@ class Member(AbstractUser):
                               language=self.preferences.language) # pylint: disable=no-member
 
     def delete(self, *args, **kwargs):
+        """ when we get deleted, remove plans for future gigs and set us to deleted """
+        Plan.member_plans.future_plans(self).delete()
         self.status = MemberStatusChoices.DELETED
+        self.save()
 
     objects = MemberManager()
 

--- a/member/models.py
+++ b/member/models.py
@@ -150,6 +150,7 @@ class Member(AbstractUser):
         self.email = "user_{0}@gig-o-matic.com".format(self.id)
         self.phone = ''
         self.statement = ''
+        self.set_unusable_password()
         self.save()
 
     objects = MemberManager()

--- a/member/models.py
+++ b/member/models.py
@@ -148,6 +148,8 @@ class Member(AbstractUser):
         Plan.member_plans.future_plans(self).filter(gig__is_archived=False).delete()
         self.status = MemberStatusChoices.DELETED
         self.email = "user_{0}@gig-o-matic.com".format(self.id)
+        self.phone = ''
+        self.statement = ''
         self.save()
 
     objects = MemberManager()

--- a/member/models.py
+++ b/member/models.py
@@ -145,7 +145,7 @@ class Member(AbstractUser):
 
     def delete(self, *args, **kwargs):
         """ when we get deleted, remove plans for future gigs and set us to deleted """
-        Plan.member_plans.future_plans(self).delete()
+        Plan.member_plans.future_plans(self).filter(gig__is_archived=False).delete()
         self.status = MemberStatusChoices.DELETED
         self.email = "user_{0}@gig-o-matic.com".format(self.id)
         self.save()

--- a/member/models.py
+++ b/member/models.py
@@ -145,9 +145,9 @@ class Member(AbstractUser):
 
     def delete(self, *args, **kwargs):
         """ when we get deleted, remove plans for future gigs and set us to deleted """
-        # Plan.member_plans.future_plans(self).delete()
+        Plan.member_plans.future_plans(self).delete()
         self.status = MemberStatusChoices.DELETED
-        # self.save()
+        self.save()
 
     objects = MemberManager()
 

--- a/member/models.py
+++ b/member/models.py
@@ -145,9 +145,9 @@ class Member(AbstractUser):
 
     def delete(self, *args, **kwargs):
         """ when we get deleted, remove plans for future gigs and set us to deleted """
-        Plan.member_plans.future_plans(self).delete()
+        # Plan.member_plans.future_plans(self).delete()
         self.status = MemberStatusChoices.DELETED
-        self.save()
+        # self.save()
 
     objects = MemberManager()
 

--- a/member/tests.py
+++ b/member/tests.py
@@ -877,9 +877,29 @@ class MemberDeleteTest(TestCase):
         self.assertEqual(self.joeuser.status, MemberStatusChoices.DELETED)
         self.assertFalse(self.joeuser.is_active)
 
-    # test logging in not allowed for deleted user
+    # test deleting user sets email address to something anonymous
+    def test_delete_member_email(self):
+        self.assertEqual(self.joeuser.email, 'joeuser@h.i')
+        self.joeuser.delete()
+        self.assertEqual(self.joeuser.email, 'user_{0}@gig-o-matic.com'.format(self.joeuser.id))
+
     # test creating a gig does not create a plan for a deleted user
+    def test_delete_member_noplans(self):
+        g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
+        self.assertEqual(Plan.objects.filter(gig=g).count(), 2)
+        Plan.objects.all().delete()
+        self.joeuser.delete()
+        g2 = self.create_gig_form(contact=self.band_admin, user=self.band_admin)
+        self.assertEqual(Plan.objects.filter(gig=g2).count(), 1)
+
     # test deleting a user also deletes gig plans for future gigs
-    # test deleted uses don't show up on gig detail page
+    def test_delete_future_plans(self):
+        g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
+        self.assertEqual(Plan.objects.filter(gig=g).count(), 2)
+        self.joeuser.delete()
+        self.assertEqual(Plan.objects.filter(gig=g).count(), 1)
+
+    # test deleted users don't show up on gig detail page
     # test deleted user shows up on archived gig page
+    # test logging in not allowed for deleted user
 

--- a/member/tests.py
+++ b/member/tests.py
@@ -927,3 +927,12 @@ class MemberDeleteTest(TestCase):
         self.assertTrue(self.client.login(email=self.joeuser.email, password='ThisIsPass716'))
         self.joeuser.delete()
         self.assertFalse(self.client.login(email=self.joeuser.email, password='ThisIsPass716'))
+
+    # test deleting user erases phone and statement
+    def test_delete_personal_info(self):
+        self.joeuser.phone = '123-4567'
+        self.joeuser.statement = 'Cogito Ergo Sum'
+        self.joeuser.save()
+        self.joeuser.delete()
+        self.assertEqual(self.joeuser.phone, '')
+        self.assertEqual(self.joeuser.statement, '')

--- a/member/tests.py
+++ b/member/tests.py
@@ -17,7 +17,7 @@
 
 from unittest.mock import patch, mock_open
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, Client
 from .models import Member, MemberPreferences, Invite
 from band.models import Band, Assoc, AssocStatusChoices
 from gig.models import Gig, Plan
@@ -33,6 +33,7 @@ from django.core import mail
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.urls import resolve, reverse
 from django.utils import timezone
+from pytz import timezone as pytz_timezone
 from datetime import timedelta
 import pytz
 import os

--- a/member/tests.py
+++ b/member/tests.py
@@ -900,6 +900,30 @@ class MemberDeleteTest(TestCase):
         self.assertEqual(Plan.objects.filter(gig=g).count(), 1)
 
     # test deleted users don't show up on gig detail page
-    # test deleted user shows up on archived gig page
-    # test logging in not allowed for deleted user
+    def test_deleted_member_plans(self):
+        g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
+        p = g.member_plans
+        self.assertEqual(p.count(), 2)
+        self.joeuser.delete()
+        p2 = g.member_plans
+        self.assertEqual(p2.count(), 1)
 
+    # test deleted users show up on gig archive page
+    def test_deleted_member_plans(self):
+        g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
+        p = g.member_plans
+        self.assertEqual(p.count(), 2)
+        g.is_archived = True
+        g.save()
+        self.joeuser.delete()
+        p2 = g.member_plans
+        self.assertEqual(p2.count(), 2)
+
+    # test logging in not allowed for deleted user
+    def test_login_delete(self):
+        self.client.logout()
+        self.joeuser.set_password('ThisIsPass716')
+        self.joeuser.save()
+        self.assertTrue(self.client.login(email=self.joeuser.email, password='ThisIsPass716'))
+        self.joeuser.delete()
+        self.assertFalse(self.client.login(email=self.joeuser.email, password='ThisIsPass716'))

--- a/member/tests.py
+++ b/member/tests.py
@@ -900,7 +900,7 @@ class MemberDeleteTest(TestCase):
         self.assertEqual(Plan.objects.filter(gig=g).count(), 1)
 
     # test deleted users don't show up on gig detail page
-    def test_deleted_member_plans(self):
+    def test_deleted_member_plans_detail(self):
         g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
         p = g.member_plans
         self.assertEqual(p.count(), 2)
@@ -909,7 +909,7 @@ class MemberDeleteTest(TestCase):
         self.assertEqual(p2.count(), 1)
 
     # test deleted users show up on gig archive page
-    def test_deleted_member_plans(self):
+    def test_deleted_member_plans_archive(self):
         g, _, _ = self.assoc_joe_and_create_gig( user=self.band_admin)
         p = g.member_plans
         self.assertEqual(p.count(), 2)

--- a/member/urls.py
+++ b/member/urls.py
@@ -38,4 +38,6 @@ urlpatterns = [
     path('create/<uuid:pk>', views.MemberCreateView.as_view(), name='member-create'),
     path('signup', views.SignupView.as_view(), name='member-signup'),
 
+    path('<int:pk>/delete', helpers.delete_member, name='member-delete'),
+
 ]

--- a/member/views.py
+++ b/member/views.py
@@ -15,10 +15,11 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, HttpResponseNotFound
 from .forms import MemberCreateForm, InviteForm, SignupForm
 from .models import Member, MemberPreferences, Invite
 from band.models import Band, Assoc, AssocStatusChoices
+from member.util import MemberStatusChoices
 from lib.translation import join_trans
 from django.views import generic
 from django.views.decorators.http import require_POST
@@ -110,6 +111,13 @@ class DetailView(LoginRequiredMixin, generic.DetailView):
             context['invites'] = None
 
         return context
+
+    def render_to_response(self, context):
+        if self.object.status == MemberStatusChoices.DELETED:
+            return HttpResponseNotFound()
+        else:
+            return super().render_to_response(context)
+
 
 
 class UpdateView(BaseUpdateView):

--- a/static/js/bootstrap-show-modal.js
+++ b/static/js/bootstrap-show-modal.js
@@ -1,0 +1,139 @@
+/**
+ * Author and copyright: Stefan Haack (https://shaack.com)
+ * Repository: https://github.com/shaack/bootstrap-show-modal
+ * License: MIT, see file 'LICENSE'
+ */
+
+(function ($) {
+    "use strict"
+
+    var i = 0
+
+    function Modal(props) {
+        this.props = {
+            title: "", // the dialog title html
+            body: "", // the dialog body html
+            footer: "", // the dialog footer html (mainly used for buttons)
+            modalClass: "fade", // Additional css for ".modal", "fade" for fade effect
+            modalDialogClass: "", // Additional css for ".modal-dialog", like "modal-lg" or "modal-sm" for sizing
+            options: null, // The Bootstrap modal options as described here: https://getbootstrap.com/docs/4.0/components/modal/#options
+            // Events:
+            onCreate: null, // Callback, called after the modal was created
+            onDispose: null, // Callback, called after the modal was disposed
+            onSubmit: null // Callback of $.showConfirm(), called after yes or no was pressed
+        }
+        for (var prop in props) {
+            // noinspection JSUnfilteredForInLoop
+            this.props[prop] = props[prop]
+        }
+        this.id = "bootstrap-show-modal-" + i
+        i++
+        this.show()
+    }
+
+    Modal.prototype.createContainerElement = function () {
+        var self = this
+        this.element = document.createElement("div")
+        this.element.id = this.id
+        this.element.setAttribute("class", "modal " + this.props.modalClass)
+        this.element.setAttribute("tabindex", "-1")
+        this.element.setAttribute("role", "dialog")
+        this.element.setAttribute("aria-labelledby", this.id)
+        this.element.innerHTML = '<div class="modal-dialog ' + this.props.modalDialogClass + '" role="document">' +
+            '<div class="modal-content">' +
+            '<div class="modal-header">' +
+            '<h5 class="modal-title"></h5>' +
+            '<button type="button" class="close" data-dismiss="modal" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span>' +
+            '</button>' +
+            '</div>' +
+            '<div class="modal-body"></div>' +
+            '<div class="modal-footer"></div>' +
+            '</div>' +
+            '</div>'
+        document.body.appendChild(this.element)
+        this.titleElement = this.element.querySelector(".modal-title")
+        this.bodyElement = this.element.querySelector(".modal-body")
+        this.footerElement = this.element.querySelector(".modal-footer")
+        $(this.element).on('hidden.bs.modal', function () {
+            self.dispose()
+        })
+        if (this.props.onCreate) {
+            this.props.onCreate(this)
+        }
+    }
+
+    Modal.prototype.show = function () {
+        if (!this.element) {
+            this.createContainerElement()
+            if (this.props.options) {
+                $(this.element).modal(this.props.options)
+            } else {
+                $(this.element).modal()
+            }
+        } else {
+            $(this.element).modal('show')
+        }
+        if (this.props.title) {
+            $(this.titleElement).show()
+            this.titleElement.innerHTML = this.props.title
+        } else {
+            $(this.titleElement).hide()
+        }
+        if (this.props.body) {
+            $(this.bodyElement).show()
+            this.bodyElement.innerHTML = this.props.body
+        } else {
+            $(this.bodyElement).hide()
+        }
+        if (this.props.footer) {
+            $(this.footerElement).show()
+            this.footerElement.innerHTML = this.props.footer
+        } else {
+            $(this.footerElement).hide()
+        }
+    }
+
+    Modal.prototype.hide = function () {
+        $(this.element).modal('hide')
+    }
+
+    Modal.prototype.dispose = function () {
+        $(this.element).modal('dispose')
+        document.body.removeChild(this.element)
+        if (this.props.onDispose) {
+            this.props.onDispose(this)
+        }
+    }
+
+    $.extend({
+        showModal: function (props) {
+            if (props.buttons) {
+                var footer = ""
+                for (var key in props.buttons) {
+                    // noinspection JSUnfilteredForInLoop
+                    var buttonText = props.buttons[key]
+                    footer += '<button type="button" class="btn btn-primary" data-value="' + key + '" data-dismiss="modal">' + buttonText + '</button>'
+                }
+                props.footer = footer
+            }
+            return new Modal(props)
+        },
+        showAlert: function (props) {
+            props.buttons = {OK: 'OK'}
+            return this.showModal(props)
+        },
+        showConfirm: function (props) {
+            props.footer = '<button class="btn btn-secondary btn-false btn-cancel">' + props.textFalse + '</button><button class="btn btn-primary btn-true">' + props.textTrue + '</button>'
+            props.onCreate = function (modal) {
+                $(modal.element).on("click", ".btn", function (event) {
+                    event.preventDefault()
+                    modal.hide()
+                    modal.props.onSubmit(event.target.getAttribute("class").indexOf("btn-true") !== -1, modal)
+                })
+            }
+            return this.showModal(props)
+        }
+    })
+
+}(jQuery))

--- a/templates/base/go3base.html
+++ b/templates/base/go3base.html
@@ -116,7 +116,7 @@
     <!-- <script src="/bootstrap3-editable/js/bootstrap-editable.js"></script>     -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/x-editable/1.5.0/jqueryui-editable/js/jqueryui-editable.min.js"></script>
 
-    <script src="https://unpkg.com/htmx.org@0.0.8"></script>
+    <script src="https://unpkg.com/htmx.org@0.1.2"></script>
     <script>
         document.body.addEventListener('htmx:configRequest', (event) => {
             event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -231,7 +231,7 @@
                         </div>
                     </div>
                 {% endif %}
-                {% regroup gig.member_plans_active.all by section as plans_by_section %}
+                {% regroup gig.member_plans.all by section as plans_by_section %}
                 {% for section in band.sections.all %}
                     <div class="row" style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
                         {% if band.sections.all|length > 1 %}

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -231,7 +231,7 @@
                         </div>
                     </div>
                 {% endif %}
-                {% regroup gig.member_plans.all by section as plans_by_section %}
+                {% regroup gig.member_plans_active.all by section as plans_by_section %}
                 {% for section in band.sections.all %}
                     <div class="row" style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
                         {% if band.sections.all|length > 1 %}

--- a/templates/member/member_detail.html
+++ b/templates/member/member_detail.html
@@ -199,7 +199,7 @@
                         <div class="d-none d-sm-inline col-sm-3">{% include "base/tf.html" with value=member.preferences.calendar_show_only_committed %}</div>
                         <div class="col-12 d-sm-none">{% trans "Calendar shows only gigs I can do (or maybe can do)" %}: {% include "base/tf.html" with value=member.preferences.calendar_show_only_committed %}</div>
                     </div>
-                    {% if the_user_is_superuser %}
+                    {% if request.user.is_superuser %}
                         <br>
                         <div class="row">
                             <div class="col-sm-3 col-12">Verified:</div>
@@ -214,8 +214,8 @@
                         <div class="row">
                             <div class="col-sm-3 col-12">{% trans "Last Activity:" %}</div>
                             <div class="col-sm-9 col-12">
-                                {% if  member.last_activity %}
-                                    {{  member.last_activity }}
+                                {% if  member.last_login %}
+                                    {{  member.last_login }}
                                 {% else %}
                                     None since 2014-10-18
                                 {% endif %}

--- a/templates/member/member_form.html
+++ b/templates/member/member_form.html
@@ -60,7 +60,7 @@
  -->
             </div>
             <div class="row mt-4">
-                {% if request.user.is_superuser %}
+                {% if request.user.is_superuser or request.user == member %}
                     <div class="form-group col-12 col-md-6">
                         <a hx-confirm="{% trans 'Are you sure you want to delete this account?' %}"
                            href="{% url 'member-delete' pk=member.id %}" class="btn btn-secondary">{% trans "Delete" %}</a>

--- a/templates/member/member_form.html
+++ b/templates/member/member_form.html
@@ -1,7 +1,7 @@
 {% extends 'base/go3base.html' %}
 {% load i18n %}
 {% load widget_tweaks %}
-
+{% load static %}
 {% block title %}{% trans "Edit Profile" %}{% endblock title %}
 
 {% block content %}
@@ -62,8 +62,7 @@
             <div class="row mt-4">
                 {% if request.user.is_superuser or request.user == member %}
                     <div class="form-group col-12 col-md-6">
-                        <a hx-confirm="{% trans 'Are you sure you want to delete this account?' %}"
-                           href="{% url 'member-delete' pk=member.id %}" class="btn btn-secondary">{% trans "Delete" %}</a>
+                        <a onclick='handle_delete()' href='javascript:return false;' class="btn btn-secondary">{% trans "Delete" %}</a>
                     </div>
                 {% endif %}
                 <div class="form-group col-12 col-md-6 ml-auto text-right">
@@ -75,3 +74,28 @@
     </div>
 </div>
 {% endblock content %}
+
+{% block localscripts %}
+<script src="{% static 'js/bootstrap-show-modal.js' %}"></script>
+<script>
+
+function handle_delete() {
+    $.showConfirm({
+        title: "Confirm Delete", body: "Are you sure you want to delete this account?", textTrue: "Yes, Delete", textFalse: "Cancel",
+        onSubmit: function (result) { // callback on confirm
+            if (result) {
+                $.showConfirm({
+                    title: "Confirm Delete", body: "Really? This can't be undone!", textTrue: "Yes, Delete", textFalse: "Cancel",
+                    onSubmit: function (result) { // callback on confirm
+                        if (result) {
+                            window.location.replace("{% url 'member-delete' pk=member.id %}")
+                        }
+                    }
+                })
+            }
+        }
+    })
+}
+
+</script>
+{% endblock localscripts %}

--- a/templates/member/member_form.html
+++ b/templates/member/member_form.html
@@ -62,11 +62,12 @@
             <div class="row mt-4">
                 {% if request.user.is_superuser %}
                     <div class="form-group col-12 col-md-6">
-                        <a data-toggle="modal" href="#deleteModal" class="btn btn-secondary">{% trans "Delete" %}</a>
+                        <a hx-confirm="{% trans 'Are you sure you want to delete this account?' %}"
+                           href="{% url 'member-delete' pk=member.id %}" class="btn btn-secondary">{% trans "Delete" %}</a>
                     </div>
                 {% endif %}
                 <div class="form-group col-12 col-md-6 ml-auto text-right">
-                    <a class="btn btn-secondary" href="{% url 'member-detail' pk=1 %}">{% trans "Cancel" %}</a>
+                    <a class="btn btn-secondary" href="{% url 'member-detail' pk=member.id %}">{% trans "Cancel" %}</a>
                     <button value="Update" type="submit" class="btn btn-primary">{% trans "Save" %}</button>
                 </div>
             </div>


### PR DESCRIPTION
Added code to delete a member. This just sets their status to 'deleted.' Plans for future gigs are deleted and those members don't show up on the band page or gig detail pages anymore. They do still show up in archived gigs. When a user is deleted, their phone number, email address, and 'personal statement' are cleared, but if they had entered a name/nickname, it stays around.