### PR TITLE
added tests and fixes to handle deleting band

### DIFF
--- a/band/models.py
+++ b/band/models.py
@@ -56,7 +56,6 @@ class Band(models.Model):
 
     status = models.IntegerField(choices=BandStatusChoices.choices, default=BandStatusChoices.ACTIVE)
 
-
     creation_date = models.DateField(auto_now_add=True)
     last_activity = models.DateTimeField(auto_now=True)
 

--- a/band/signals.py
+++ b/band/signals.py
@@ -29,6 +29,13 @@ def set_default_section(sender, instance, created, **kwargs):
     if created:
         _ = Section.objects.create(name='No Section', band=instance, is_default=True, order=999)
 
+@receiver(pre_delete, sender=Band)
+def delete_band_parts(sender, instance, **kwargs):
+    # when deleting a band, we need to delete the assocs first; otherwise when the sections delete and the
+    # assocs reset to the default section, things go badly.
+    l=Assoc.objects.filter(band=instance)
+    l.delete()
+
 @receiver(pre_save, sender=Assoc)
 def set_initial_default_section(sender, instance, **kwargs):
     if instance.default_section is None:

--- a/band/tests.py
+++ b/band/tests.py
@@ -19,6 +19,7 @@ from django.test import TestCase, RequestFactory
 from django.urls import reverse
 from .models import Band, Assoc, Section
 from member.models import Member
+from gig.models import Gig, Plan
 from band import helpers
 from member.util import MemberStatusChoices
 from band.util import AssocStatusChoices
@@ -419,4 +420,30 @@ class BandTests(GigTestBase):
         defsecs = self.band.sections.filter(is_default=True)
         self.assertEqual(defsecs.count(), 1)
         self.assertEqual(defsec.id, defsecs.first().id)
+
+    def test_delete_band(self):
+        # set up some sections in the band
+        section1 = Section.objects.create(name='section a', order=1, band=self.band, is_default=False)
+        section2 = Section.objects.create(name='section b', order=2, band=self.band, is_default=False)
+
+        g, a1, _ = self.assoc_joe_and_create_gig()
+        a1.default_section = section1
+        a1.save()
+
+        a2 = Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+
+        # at this point, we should have one band, three sections, three assocs, three plans
+        self.assertEqual(Band.objects.count(),1)
+        self.assertEqual(Section.objects.count(),3)
+        self.assertEqual(Assoc.objects.count(),3)
+        self.assertEqual(g.member_plans.count(),3)
+
+        self.band.delete()
+        # should be no bands, no sections, no assocs, no member plans
+        self.assertEqual(Band.objects.count(),0)
+        self.assertEqual(Section.objects.count(),0)
+        self.assertEqual(Assoc.objects.count(),0)
+        self.assertEqual(Gig.objects.count(),0)
+        self.assertEqual(Plan.objects.count(),0)
+
 

--- a/band/tests.py
+++ b/band/tests.py
@@ -431,6 +431,8 @@ class BandTests(GigTestBase):
         a1.save()
 
         a2 = Assoc.objects.create(member=self.janeuser, band=self.band, status=AssocStatusChoices.CONFIRMED)
+        a2.default_section = section2
+        a2.save()
 
         # at this point, we should have one band, three sections, three assocs, three plans
         self.assertEqual(Band.objects.count(),1)

--- a/templates/band/band_form.html
+++ b/templates/band/band_form.html
@@ -153,13 +153,7 @@
                 <input type="hidden" name="bk" value="{{form.instance.id}}">
             {% endif %}
 
-
             <div class="row mt-4">
-                {% if request.user.is_superuser %}
-                    <div class="form-group col-12 col-md-6">
-                        <a data-toggle="modal" href="#deleteModal" class="btn btn-secondary">{% trans "Delete" %}</a>
-                    </div>
-                {% endif %}
                 <div class="form-group col-12 col-md-6 ml-auto text-right">
                     <a class="btn btn-secondary" href="{% url 'band-detail' pk=form.instance.id %}">{% trans "Cancel" %}</a>
                     <button value="Update" type="submit" class="btn btn-primary">{% trans "Save" %}</button>


### PR DESCRIPTION
added tests to confirm things get deleted properly when a band is deleted. Turns out order is important so made sure assocs are deleted before anything else.